### PR TITLE
Add puma

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'select2-rails', '3.5.7'
 gem 'activerecord-import'
 gem 'sidekiq', '4.1.1'
 gem 'aws-sdk-s3', '~> 1.45'
+gem 'puma' , '~> 4.1.0'
 
 gem 'sass'
 gem 'sass-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -453,6 +453,7 @@ DEPENDENCIES
   pg
   plek
   pry
+  puma (~> 4.1.0)
   rails (= 5.1.6.2)
   rails-controller-testing
   rails_warden (= 0.5.8)


### PR DESCRIPTION
puma is the de facto standard for serving ruby apps these days. We
should use it.