### PR TITLE
Fix CI so that it can run the test suite again

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-GOVUK_APP_DOMAIN=localhost:3000
 ZD_CLIENT=transition_dev
 ZD_SECRET=
 ZD_HOST=https://dxw.zendesk.com

--- a/.github/workflows/.continuous-integration.yml
+++ b/.github/workflows/.continuous-integration.yml
@@ -10,20 +10,26 @@ jobs:
     - uses: actions/setup-ruby@v1
       with:
         ruby-version: '2.6.3'
-    - name: Install Postgres dependencies
-      run: |
-        sudo apt-get install libpq-dev
+    - name: Set up Docker
+      run: docker network create test
     - name: Set up Postgres
+      run: docker run -d --name pg --network test -e POSTGRES_USER=transition -p 5432:5432 postgres:11
+    - name: Set up Redis
+      run: docker run -d --name redis --network test -p 6379:6379 redis
+    - name: Build a new Docker image
+      run: docker build . --build-arg RAILS_ENV=test -t transition:test
+    - name: Set up a new container for testing
       run: |
-        docker run -d --name postgres -e POSTGRES_USER=transition -p 5432:5432 postgres:11
-    - name: Install dependencies
-      run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
+        docker run -d --name test-container \
+          --network test \
+          -e RAILS_ENV=test \
+          -e GOVUK_TEST_USE_SYSTEM_CHROMEDRIVER=true \
+          -e DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL=true \
+          -e DATABASE_URL=postgres://transition@pg:5432/transition_test \
+          -e REDIS_URL=redis://redis:6379 \
+          -e GOVUK_APP_DOMAIN=dev.gov.uk \
+          transition:test /bin/bash -c "tail -f /dev/null"
     - name: Set up the test database
-      run: |
-        RAILS_ENV=test \
-        bundle exec rake db:setup
+      run: docker exec test-container rake db:setup
     - name: Run the tests
-      run: |
-        bundle exec rake
+      run: docker exec test-container rake

--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,11 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'database_cleaner'
   gem 'factory_bot_rails'
-  gem 'govuk_test', '~> 1.0.0'
+  gem 'poltergeist'
+  gem 'cuprite'
+  gem 'capybara'
+  gem 'selenium-webdriver'
+  gem 'webdrivers'
   gem 'launchy' # Primarily for save_and_open_page support in Capybara
   gem 'rails-controller-testing'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,9 +84,10 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (~> 1.5)
       xpath (~> 3.2)
-    childprocess (1.0.1)
+    childprocess (2.0.0)
       rake (< 13.0)
     chronic (0.10.2)
+    cliver (0.3.2)
     coderay (1.1.2)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
@@ -115,6 +116,9 @@ GEM
       railties (>= 4.2, < 7)
     cucumber-tag_expressions (1.1.1)
     cucumber-wire (0.0.1)
+    cuprite (0.7.0)
+      capybara (>= 2.1, < 4)
+      ferrum (>= 0.2.1)
     database_cleaner (1.7.0)
     declarative (0.0.10)
     declarative-option (0.1.0)
@@ -134,6 +138,11 @@ GEM
       railties (>= 4.2.0)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
+    ferrum (0.4)
+      addressable (~> 2.6)
+      cliver (~> 0.3)
+      concurrent-ruby (~> 1.1)
+      websocket-driver (>= 0.6, < 0.8)
     ffi (1.11.1)
     gds-api-adapters (60.0.0)
       addressable
@@ -175,11 +184,6 @@ GEM
       sentry-raven (>= 2.7.1, < 2.12.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_test (1.0.0)
-      capybara
-      puma
-      selenium-webdriver (>= 3.142)
-      webdrivers
     gretel (3.0.9)
       rails (>= 3.1.0)
     hashdiff (1.0.0)
@@ -278,6 +282,10 @@ GEM
     pg (1.1.4)
     phantomjs (2.1.1.0)
     plek (3.0.0)
+    poltergeist (1.18.1)
+      capybara (>= 2.1, < 4)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -375,7 +383,7 @@ GEM
     rubocop-rspec (1.33.0)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.1)
-    rubyzip (1.2.3)
+    rubyzip (1.2.4)
     safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -398,8 +406,8 @@ GEM
       sass (~> 3.5, >= 3.5.5)
     select2-rails (3.5.7)
       thor (~> 0.14)
-    selenium-webdriver (3.142.3)
-      childprocess (>= 0.5, < 2.0)
+    selenium-webdriver (3.142.4)
+      childprocess (>= 0.5, < 3.0)
       rubyzip (~> 1.2, >= 1.2.2)
     sentry-raven (2.11.0)
       faraday (>= 0.7.6, < 1.0)
@@ -446,7 +454,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webdrivers (4.0.1)
+    webdrivers (4.1.2)
       nokogiri (~> 1.6)
       rubyzip (~> 1.0)
       selenium-webdriver (>= 3.0, < 4.0)
@@ -471,7 +479,9 @@ DEPENDENCIES
   acts-as-taggable-on
   aws-sdk-s3 (~> 1.48)
   bootstrap-sass (= 3.4.1)
+  capybara
   cucumber-rails
+  cuprite
   database_cleaner
   dotenv-rails
   factory_bot_rails
@@ -480,7 +490,6 @@ DEPENDENCIES
   govuk-lint (~> 3.11.5)
   govuk_admin_template
   govuk_app_config (~> 2.0)
-  govuk_test (~> 1.0.0)
   gretel
   htmlentities
   jasmine
@@ -493,6 +502,7 @@ DEPENDENCIES
   paper_trail (~> 9.0)
   pg
   plek
+  poltergeist
   pry
   puma (~> 4.1)
   rails (= 5.1.6.2)
@@ -505,11 +515,13 @@ DEPENDENCIES
   sass
   sass-rails
   select2-rails (= 3.5.7)
+  selenium-webdriver
   shoulda-matchers
   sidekiq (~> 5.2)
   timecop
   uglifier
   web-console
+  webdrivers
   webmock
   whenever
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,6 @@
-require 'factory_bot'
-FactoryBot.find_definitions
-
 if Rails.env.development?
+  require 'factory_bot'
+  FactoryBot.find_definitions
   unless User.find_by_email("test@example.com")
     u             = User.new
     u.email       = "test@example.com"

--- a/features/support/govuk_test.rb
+++ b/features/support/govuk_test.rb
@@ -1,1 +1,0 @@
-GovukTest.configure

--- a/features/support/selenium.rb
+++ b/features/support/selenium.rb
@@ -1,0 +1,13 @@
+require 'selenium-webdriver'
+
+options = Selenium::WebDriver::Chrome::Options.new
+options.headless!
+options.add_argument('no-sandbox')
+options.add_argument('disable-dev-shm-usage')
+
+Capybara.register_driver :headless_chrome do |app|
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.javascript_driver = :headless_chrome
+Capybara.server = :puma, { Silent: true }

--- a/spec/lib/transition/import/whitehall/mappings_spec.rb
+++ b/spec/lib/transition/import/whitehall/mappings_spec.rb
@@ -28,7 +28,7 @@ describe Transition::Import::Whitehall::Mappings do
 
   context "when downloading the file from whitehall" do
     before do
-      stub_request(:get, "https://whitehall-admin.localhost:3000/government/mappings.csv")
+      stub_request(:get, "http://whitehall-admin.dev.gov.uk/government/mappings.csv")
         .to_return(body: "some,mappings,csv")
     end
 


### PR DESCRIPTION
FactoryBot was reporting a double factory load during `rake db:setup` within GitHub Actions. The only way to test GitHub Actions is with a new pull request.