### PR TITLE
(chore) Apply linting autocorrections

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,30 +1,30 @@
 source 'https://rubygems.org'
 
-gem 'rails', '5.1.6.2'
-gem 'govuk_app_config', '~> 2.0'
+gem 'activerecord-import'
 gem 'activerecord-session_store'
-gem 'pg'
-gem 'optic14n' # Ideally version should be synced with bouncer
-gem 'govuk_admin_template'
+gem 'acts-as-taggable-on'
+gem 'aws-sdk-s3', '~> 1.48'
 gem 'bootstrap-sass', '3.4.1'
-gem 'plek'
+gem 'gds-api-adapters', '~> 60.0'
+gem 'google-api-client'
+gem 'govuk_admin_template'
+gem 'govuk_app_config', '~> 2.0'
+gem 'gretel'
 gem 'htmlentities'
 gem 'kaminari'
-gem 'paper_trail', '~> 9.0'
-gem 'google-api-client'
-gem 'gds-api-adapters', '~> 60.0'
 gem 'mlanett-redis-lock'
-gem 'whenever'
-gem 'gretel'
-gem 'acts-as-taggable-on'
-gem 'select2-rails', '3.5.7'
-gem 'activerecord-import'
-gem 'sidekiq', '~> 5.2'
-gem 'redis-namespace'
-gem 'aws-sdk-s3', '~> 1.48'
-gem 'rails_warden', '0.6.0'
+gem 'optic14n' # Ideally version should be synced with bouncer
+gem 'paper_trail', '~> 9.0'
+gem 'pg'
+gem 'plek'
 gem 'puma', '~> 4.1'
+gem 'rails', '5.1.6.2'
+gem 'rails_warden', '0.6.0'
+gem 'redis-namespace'
 gem 'rollbar', '~> 2.22'
+gem 'select2-rails', '3.5.7'
+gem 'sidekiq', '~> 5.2'
+gem 'whenever'
 
 # Custom authentication...
 gem 'omniauth', '1.9.0'
@@ -39,26 +39,26 @@ group :development do
 end
 
 group :test do
+  gem 'capybara'
   gem 'cucumber-rails', require: false
+  gem 'cuprite'
   gem 'database_cleaner'
   gem 'factory_bot_rails'
-  gem 'poltergeist'
-  gem 'cuprite'
-  gem 'capybara'
-  gem 'selenium-webdriver'
-  gem 'webdrivers'
   gem 'launchy' # Primarily for save_and_open_page support in Capybara
+  gem 'poltergeist'
   gem 'rails-controller-testing'
+  gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'timecop'
+  gem 'webdrivers'
   gem 'webmock', require: false
 end
 
 group :development, :test do
   gem 'dotenv-rails'
-  gem 'pry'
-  gem 'rspec-rails'
-  gem 'rspec-collection_matchers'
-  gem 'jasmine'
   gem 'govuk-lint', '~> 3.11.5'
+  gem 'jasmine'
+  gem 'pry'
+  gem 'rspec-collection_matchers'
+  gem 'rspec-rails'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -2,9 +2,9 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require File.expand_path('../config/application', __FILE__)
+require File.expand_path('config/application', __dir__)
 
 Rails.application.load_tasks
 
 task(:default).clear
-task :default => [:spec, :cucumber, 'jasmine:ci', :lint, :check_for_bad_time_handling]
+task default: [:spec, :cucumber, 'jasmine:ci', :lint, :check_for_bad_time_handling]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,4 @@
 class ApplicationController < ActionController::Base
-
   before_action :exclude_all_users_except_admins_during_maintenance
   before_action :authenticate
 

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -2,8 +2,7 @@ class AuthenticationController < ApplicationController
   # we don't need to authenticate these requests, they create the authentication
   skip_before_action :authenticate
 
-  def index
-  end
+  def index; end
 
   def new
     logger.info('OAuth Initiating to ZenDesk')

--- a/app/controllers/concerns/common_authentication.rb
+++ b/app/controllers/concerns/common_authentication.rb
@@ -2,7 +2,6 @@
 # Split out of GDS-SSO: https://github.com/alphagov/gds-sso/blob/master/lib/gds-sso/controller_methods.rb
 # repurposed to use OmniAuth and ZenDesk
 module CommonAuthentication
-
   class PermissionDeniedException < StandardError
   end
 
@@ -13,7 +12,6 @@ module CommonAuthentication
     base.helper_method :user_signed_in?
     base.helper_method :current_user
   end
-
 
   def authorise_user!(permission)
     # Ensure that we're authenticated (and by extension that current_user is set).

--- a/app/controllers/mappings_controller.rb
+++ b/app/controllers/mappings_controller.rb
@@ -109,8 +109,8 @@ class MappingsController < ApplicationController
     site = Host.where(hostname: url.host).first.try(:site)
     unless site
       render_error(404,
-          header: 'Unknown site',
-          body:  "#{url.host} isn't configured in Transition yet. To add this site to Transition, please contact your Proposition Manager.")
+                   header: 'Unknown site',
+                   body:  "#{url.host} isn't configured in Transition yet. To add this site to Transition, please contact your Proposition Manager.")
       return
     end
 

--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -1,5 +1,5 @@
 class OrganisationsController < ApplicationController
-  before_action :set_organisation, only: [:show, :update, :edit]
+  before_action :set_organisation, only: %i[show update edit]
 
   def index
     @organisations = Organisation.with_sites.order(:title)
@@ -26,8 +26,7 @@ class OrganisationsController < ApplicationController
     end
   end
 
-  def edit
-  end
+  def edit; end
 
   def update
     @organisation.update!(organisation_params)

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -1,5 +1,5 @@
 class SitesController < ApplicationController
-  before_action :find_site, only: [:edit, :update, :show]
+  before_action :find_site, only: %i[edit update show]
   before_action :check_user_is_gds_editor, only: %i[edit update]
 
   def new

--- a/app/controllers/unauthenticated_controller.rb
+++ b/app/controllers/unauthenticated_controller.rb
@@ -4,7 +4,7 @@ class UnauthenticatedController < ActionController::Metal
   include Rails.application.routes.url_helpers
   include Rails.application.routes.mounted_helpers
 
-  delegate :flash, :to => :request
+  delegate :flash, to: :request
 
   def self.call(env)
     @respond ||= action(:respond)

--- a/app/helpers/filter_helper.rb
+++ b/app/helpers/filter_helper.rb
@@ -3,9 +3,9 @@ module FilterHelper
     selected = options[:selected]
 
     link_to filter_site_mappings_path(site),
-        'class'         => "filter-option #{'filter-selected' if selected}",
-        'data-toggle'   => 'dropdown',
-        'role'          => 'button' do
+            'class'         => "filter-option #{'filter-selected' if selected}",
+            'data-toggle'   => 'dropdown',
+            'role'          => 'button' do
       "#{type} <span class=\"glyphicon glyphicon-chevron-down\"></span>".html_safe
     end
   end

--- a/app/helpers/sites_helper.rb
+++ b/app/helpers/sites_helper.rb
@@ -34,20 +34,20 @@ module SitesHelper
 
   def site_redirects_link(site)
     link_to pluralize(number_with_delimiter(site.mappings.redirects.count), 'redirect'),
-      site_mappings_path(site_id: site, type: 'redirect'),
-      class: 'link-muted'
+            site_mappings_path(site_id: site, type: 'redirect'),
+            class: 'link-muted'
   end
 
   def site_archives_link(site)
     link_to pluralize(number_with_delimiter(site.mappings.archives.count), 'archive'),
-      site_mappings_path(site_id: site, type: 'archive'),
-      class: 'link-muted'
+            site_mappings_path(site_id: site, type: 'archive'),
+            class: 'link-muted'
   end
 
   def site_unresolved_link(site)
     link_to "#{number_with_delimiter(site.mappings.unresolved.count)} unresolved",
-      site_mappings_path(site_id: site, type: 'unresolved'),
-      class: 'link-muted'
+            site_mappings_path(site_id: site, type: 'unresolved'),
+            class: 'link-muted'
   end
 
   def site_unresolved_mappings_percentage(site)

--- a/app/models/nil_user.rb
+++ b/app/models/nil_user.rb
@@ -23,7 +23,7 @@ class NilUser
     {}
   end
 
-  def can_edit_site?(site_to_edit)
+  def can_edit_site?(_site_to_edit)
     false
   end
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,19 +1,19 @@
 class Organisation < ActiveRecord::Base
   has_many :child_organisational_relationships,
-            foreign_key: :parent_organisation_id,
-            class_name: "OrganisationalRelationship"
+           foreign_key: :parent_organisation_id,
+           class_name: "OrganisationalRelationship"
   has_many :parent_organisational_relationships,
-            foreign_key: :child_organisation_id,
-            class_name: "OrganisationalRelationship",
-            dependent: :destroy
+           foreign_key: :child_organisation_id,
+           class_name: "OrganisationalRelationship",
+           dependent: :destroy
   has_many :child_organisations,
-            through: :child_organisational_relationships
+           through: :child_organisational_relationships
   has_many :parent_organisations,
-            through: :parent_organisational_relationships
+           through: :parent_organisational_relationships
 
   has_and_belongs_to_many :extra_sites,
-                           join_table: 'organisations_sites',
-                           class_name: 'Site'
+                          join_table: 'organisations_sites',
+                          class_name: 'Site'
 
   has_many :sites
   has_many :hosts, through: :sites

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -13,8 +13,8 @@ class Site < ActiveRecord::Base
   has_many :bulk_add_batches
   has_many :import_batches
   has_and_belongs_to_many :extra_organisations,
-                           join_table: 'organisations_sites',
-                           class_name: 'Organisation'
+                          join_table: 'organisations_sites',
+                          class_name: 'Organisation'
 
   validates_presence_of :tna_timestamp
   validates_presence_of :organisation

--- a/app/validators/is_path_validator.rb
+++ b/app/validators/is_path_validator.rb
@@ -2,11 +2,11 @@ class IsPathValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     if value.blank?
       record.errors.add(attribute,
-        "can't be blank") and return
+                        "can't be blank") and return
     end
     if /^[^\/]/.match?(value)
       record.errors.add(attribute,
-        'must start with a forward slash "/"') and return
+                        'must start with a forward slash "/"') and return
     end
 
     valid_path = begin
@@ -17,7 +17,7 @@ class IsPathValidator < ActiveModel::EachValidator
 
     unless valid_path
       record.errors.add attribute,
-        'contains invalid or unsafe characters (e.g. "<")'
+                        'contains invalid or unsafe characters (e.g. "<")'
     end
   end
 end

--- a/bin/autospec
+++ b/bin/autospec
@@ -8,7 +8,7 @@
 
 require 'pathname'
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+                                           Pathname.new(__FILE__).realpath)
 
 require 'rubygems'
 require 'bundler/setup'

--- a/bin/bundle
+++ b/bin/bundle
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
-ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 load Gem.bin_path('bundler', 'bundle')

--- a/bin/rspec
+++ b/bin/rspec
@@ -8,7 +8,7 @@
 
 require 'pathname'
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path("../../Gemfile",
-  Pathname.new(__FILE__).realpath)
+                                           Pathname.new(__FILE__).realpath)
 
 require 'rubygems'
 require 'bundler/setup'

--- a/bin/setup
+++ b/bin/setup
@@ -4,7 +4,7 @@ require 'fileutils'
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/bin/update
+++ b/bin/update
@@ -4,7 +4,7 @@ require 'fileutils'
 include FileUtils
 
 # path to your application root.
-APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
+APP_ROOT = Pathname.new File.expand_path('..', __dir__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,8 +82,8 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.action_mailer.default_url_options = {
-    :host => Addressable::URI.parse(Plek.new.external_url_for('transition')).host,
-    :protocol => 'https'
+    host: Addressable::URI.parse(Plek.new.external_url_for('transition')).host,
+    protocol: 'https'
   }
   config.action_mailer.delivery_method = :ses
 

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -8,4 +8,4 @@ Rails.application.config.assets.version = '1.0'
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
-Rails.application.config.assets.precompile += %w( html5.js respond.min.js )
+Rails.application.config.assets.precompile += %w(html5.js respond.min.js)

--- a/config/initializers/current_release_sha.rb
+++ b/config/initializers/current_release_sha.rb
@@ -1,6 +1,6 @@
-if File.exists?("#{Rails.root}/REVISION")
+if File.exist?("#{Rails.root}/REVISION")
   revision = `cat #{Rails.root}/REVISION`.chomp
   CURRENT_RELEASE_SHA = revision[0..10] # Just get the short SHA
 else
-  CURRENT_RELEASE_SHA = "development"
+  CURRENT_RELEASE_SHA = "development".freeze
 end

--- a/config/initializers/warden.rb
+++ b/config/initializers/warden.rb
@@ -10,13 +10,11 @@ class Warden::SessionSerializer
 
   def deserialize(keys)
     klass, id = keys
-    klass.find(:first, :conditions => { :id => id })
+    klass.find(:first, conditions: { id: id })
   end
 end
 
-Warden::Manager.serialize_into_session do |user|
-  user.id
-end
+Warden::Manager.serialize_into_session(&:id)
 
 Warden::Manager.serialize_from_session do |id|
   User.find(id)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,11 +5,11 @@ Rails.application.routes.draw do
   resources :style, only: [:index]
   resources :glossary, only: [:index]
 
-  match '/400' => 'errors#error_400', via: [:get, :post]
-  match '/403' => 'errors#error_403', via: [:get, :post]
-  match '/404' => 'errors#error_404', via: [:get, :post]
-  match '/422' => 'errors#error_422', via: [:get, :post]
-  match '/500' => 'errors#error_500', via: [:get, :post]
+  match '/400' => 'errors#error_400', via: %i[get post]
+  match '/403' => 'errors#error_403', via: %i[get post]
+  match '/404' => 'errors#error_404', via: %i[get post]
+  match '/422' => 'errors#error_422', via: %i[get post]
+  match '/500' => 'errors#error_500', via: %i[get post]
 
   get 'login', to: 'authentication#new'
   get 'auth/zendesk/callback', to: 'authentication#create'
@@ -26,9 +26,8 @@ Rails.application.routes.draw do
   get 'leaderboard', to: 'leaderboard#index'
 
   resources :sites, except: [:destroy] do
-
     get 'mappings/find', as: 'mapping_find'
-    resources :mappings, only: [:index, :edit, :update] do
+    resources :mappings, only: %i[index edit update] do
       resources :versions, only: [:index]
 
       collection do
@@ -37,14 +36,14 @@ Rails.application.routes.draw do
 
         get 'filter'
 
-        resources :bulk_add_batches, only: [:new, :create] do
+        resources :bulk_add_batches, only: %i[new create] do
           member do
             get 'preview'
             post 'import'
           end
         end
 
-        resources :import_batches, only: [:new, :create] do
+        resources :import_batches, only: %i[new create] do
           member do
             get 'preview'
             post 'import'
@@ -64,6 +63,6 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
-    resources :whitelisted_hosts, only: [:index, :new, :create]
+    resources :whitelisted_hosts, only: %i[index new create]
   end
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,6 +1,6 @@
 # default cron env is "/usr/bin:/bin" which is not sufficient as govuk_env is in /usr/local/bin
 env :PATH, '/usr/local/bin:/usr/bin:/bin'
-set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
+set :output, error: 'log/cron.error.log', standard: 'log/cron.log'
 job_type :rake, 'cd :path && /usr/local/bin/govuk_setenv transition bundle exec rake :task :output'
 
 # Run when the file has just been generated.

--- a/db/migrate/20130910133049_create_users.rb
+++ b/db/migrate/20130910133049_create_users.rb
@@ -1,11 +1,11 @@
 class CreateUsers < ActiveRecord::Migration
   def change
-    create_table "users", :force => true do |t|
+    create_table "users", force: true do |t|
       t.string   "name"
       t.string   "email"
       t.string   "uid"
       t.text     "permissions"
-      t.boolean  "remotely_signed_out", :default => false
+      t.boolean  "remotely_signed_out", default: false
       t.timestamps
     end
   end

--- a/db/migrate/20130910135517_create_all_stilluseful_tables.rb
+++ b/db/migrate/20130910135517_create_all_stilluseful_tables.rb
@@ -1,58 +1,58 @@
 class CreateAllStillusefulTables < ActiveRecord::Migration
   def change
-    create_table "hosts", :force => true do |t|
+    create_table "hosts", force: true do |t|
       t.integer  "site_id"
       t.string   "hostname"
       t.integer  "ttl"
       t.string   "cname"
       t.string   "live_cname"
-      t.datetime "created_at", :null => false
-      t.datetime "updated_at", :null => false
+      t.datetime "created_at", null: false
+      t.datetime "updated_at", null: false
     end
 
-    add_index "hosts", ["hostname"], :name => "index_hosts_on_host", :unique => true
-    add_index "hosts", ["site_id"],  :name => "index_hosts_on_site_id"
+    add_index "hosts", %w[hostname], name: "index_hosts_on_host", unique: true
+    add_index "hosts", %w[site_id],  name: "index_hosts_on_site_id"
 
-    create_table "mappings",    :force => true do |t|
-      t.integer "site_id",      :null => false
-      t.string  "path",         :limit => 1024, :null => false
-      t.string  "path_hash",    :limit => 40,   :null => false
-      t.string  "http_status",  :limit => 3,    :null => false
+    create_table "mappings",    force: true do |t|
+      t.integer "site_id",      null: false
+      t.string  "path",         limit: 1024, null: false
+      t.string  "path_hash",    limit: 40,   null: false
+      t.string  "http_status",  limit: 3,    null: false
       t.text    "new_url"
       t.text    "suggested_url"
       t.text    "archive_url"
     end
 
-    add_index "mappings", ["site_id", "http_status"], :name => "index_mappings_on_site_id_and_http_status"
-    add_index "mappings", ["site_id", "path_hash"], :name => "index_mappings_on_site_id_and_path_hash", :unique => true
-    add_index "mappings", ["site_id"], :name => "index_mappings_on_site_id"
+    add_index "mappings", %w[site_id http_status], name: "index_mappings_on_site_id_and_http_status"
+    add_index "mappings", %w[site_id path_hash], name: "index_mappings_on_site_id_and_path_hash", unique: true
+    add_index "mappings", %w[site_id], name: "index_mappings_on_site_id"
 
-    create_table "organisations", :force => true do |t|
+    create_table "organisations", force: true do |t|
       t.string   "abbr"
       t.string   "title"
       t.date     "launch_date"
       t.string   "homepage"
       t.string   "furl"
-      t.datetime "created_at",                               :null => false
-      t.datetime "updated_at",                               :null => false
+      t.datetime "created_at",                               null: false
+      t.datetime "updated_at",                               null: false
       t.string   "css"
     end
 
-    add_index "organisations", ["abbr"], :name => "index_organisations_on_abbr", :unique => true
+    add_index "organisations", %w[abbr], name: "index_organisations_on_abbr", unique: true
 
-    create_table "sites", :force => true do |t|
+    create_table "sites", force: true do |t|
       t.integer  "organisation_id"
       t.string   "abbr"
       t.string   "query_params"
       t.datetime "tna_timestamp"
       t.string   "homepage"
-      t.datetime "created_at",                      :null => false
-      t.datetime "updated_at",                      :null => false
-      t.string   "global_http_status", :limit => 3
+      t.datetime "created_at",                      null: false
+      t.datetime "updated_at",                      null: false
+      t.string   "global_http_status", limit: 3
       t.text     "global_new_url"
     end
 
-    add_index "sites", ["organisation_id"], :name => "index_sites_on_organisation_id"
-    add_index "sites", ["abbr"], :name => "index_sites_on_site", :unique => true
+    add_index "sites", %w[organisation_id], name: "index_sites_on_organisation_id"
+    add_index "sites", %w[abbr], name: "index_sites_on_site", unique: true
   end
 end

--- a/db/migrate/20130913124740_create_mappings_staging.rb
+++ b/db/migrate/20130913124740_create_mappings_staging.rb
@@ -1,8 +1,8 @@
 class CreateMappingsStaging < ActiveRecord::Migration
   def change
     create_table :mappings_staging, id: false do |t|
-      t.text :old_url , limit: 16777215
-      t.text :new_url , limit: 16777215
+      t.text :old_url, limit: 16777215
+      t.text :new_url, limit: 16777215
       t.string :http_status, length: 3
       t.string :host, length: 512
       t.string :path, length: 1024

--- a/db/migrate/20130918110810_create_versions.rb
+++ b/db/migrate/20130918110810_create_versions.rb
@@ -1,20 +1,20 @@
 class CreateVersions < ActiveRecord::Migration
   def self.up
     create_table :versions do |t|
-      t.string   :item_type, :null => false
-      t.integer  :item_id,   :null => false
-      t.string   :event,     :null => false
+      t.string   :item_type, null: false
+      t.integer  :item_id,   null: false
+      t.string   :event,     null: false
       t.string   :whodunnit
       t.integer  :user_id
       t.text     :object_changes
       t.text     :object
       t.datetime :created_at
     end
-    add_index :versions, [:item_type, :item_id]
+    add_index :versions, %i[item_type item_id]
   end
 
   def self.down
-    remove_index :versions, [:item_type, :item_id]
+    remove_index :versions, %i[item_type item_id]
     drop_table :versions
   end
 end

--- a/db/migrate/20130925162249_create_hits.rb
+++ b/db/migrate/20130925162249_create_hits.rb
@@ -11,9 +11,9 @@ class CreateHits < ActiveRecord::Migration
       t.timestamps
     end
 
-    add_index :hits, [:host_id, :path_hash, :hit_on, :http_status], unique: true
+    add_index :hits, %i[host_id path_hash hit_on http_status], unique: true
     add_index :hits, [:host_id]
-    add_index :hits, [:host_id, :hit_on]
-    add_index :hits, [:host_id, :http_status]
+    add_index :hits, %i[host_id hit_on]
+    add_index :hits, %i[host_id http_status]
   end
 end

--- a/db/migrate/20131106102619_create_daily_hit_totals.rb
+++ b/db/migrate/20131106102619_create_daily_hit_totals.rb
@@ -7,6 +7,6 @@ class CreateDailyHitTotals < ActiveRecord::Migration
       t.date :total_on, null: false
     end
 
-    add_index :daily_hit_totals, [:host_id, :total_on, :http_status], unique: true
+    add_index :daily_hit_totals, %i[host_id total_on http_status], unique: true
   end
 end

--- a/db/migrate/20131112133657_add_managed_by_transition_to_site.rb
+++ b/db/migrate/20131112133657_add_managed_by_transition_to_site.rb
@@ -1,8 +1,8 @@
 class AddManagedByTransitionToSite < ActiveRecord::Migration
   def up
-    add_column :sites, :managed_by_transition, :boolean, :null => false, :default => true
+    add_column :sites, :managed_by_transition, :boolean, null: false, default: true
 
-    Site.update_all :managed_by_transition => false
+    Site.update_all managed_by_transition: false
   end
 
   def down

--- a/db/migrate/20131128150000_set_organisational_relationships.rb
+++ b/db/migrate/20131128150000_set_organisational_relationships.rb
@@ -8,16 +8,16 @@ class SetOrganisationalRelationships < ActiveRecord::Migration
     belongs_to :parent, class_name: Organisation, foreign_key: 'parent_id'
 
     has_many :child_organisational_relationships,
-              foreign_key: :parent_organisation_id,
-              class_name: "OrganisationalRelationship"
+             foreign_key: :parent_organisation_id,
+             class_name: "OrganisationalRelationship"
     has_many :parent_organisational_relationships,
-              foreign_key: :child_organisation_id,
-              class_name: "OrganisationalRelationship",
-              dependent: :destroy
+             foreign_key: :child_organisation_id,
+             class_name: "OrganisationalRelationship",
+             dependent: :destroy
     has_many :child_organisations,
-              through: :child_organisational_relationships
+             through: :child_organisational_relationships
     has_many :parent_organisations,
-              through: :parent_organisational_relationships
+             through: :parent_organisational_relationships
   end
 
   def up

--- a/db/migrate/20140127151418_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20140127151418_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -10,18 +10,18 @@ class ActsAsTaggableOnMigration < ActiveRecord::Migration
 
       # You should make sure that the column created is
       # long enough to store the required class names.
-      t.references :taggable, :polymorphic => true
-      t.references :tagger, :polymorphic => true
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
 
       # Limit is created to prevent MySQL error on index
       # length for MyISAM table type: http://bit.ly/vgW2Ql
-      t.string :context, :limit => 128
+      t.string :context, limit: 128
 
       t.datetime :created_at
     end
 
     add_index :taggings, :tag_id
-    add_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings, %i[taggable_id taggable_type context]
   end
 
   def self.down

--- a/db/migrate/20140127151419_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20140127151419_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,14 +1,13 @@
 # This migration comes from acts_as_taggable_on_engine (originally 2)
 class AddMissingUniqueIndices < ActiveRecord::Migration
-
   def self.up
     add_index :tags, :name, unique: true
 
     remove_index :taggings, :tag_id
-    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    remove_index :taggings, %i[taggable_id taggable_type context]
     add_index :taggings,
-      [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
-      unique: true, name: 'taggings_idx'
+              %i[tag_id taggable_id taggable_type context tagger_id tagger_type],
+              unique: true, name: 'taggings_idx'
    end
 
   def self.down
@@ -16,7 +15,6 @@ class AddMissingUniqueIndices < ActiveRecord::Migration
 
     remove_index :taggings, name: 'tagging_idx'
     add_index :taggings, :tag_id
-    add_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings, %i[taggable_id taggable_type context]
   end
-
 end

--- a/db/migrate/20140225152616_add_sessions_table.rb
+++ b/db/migrate/20140225152616_add_sessions_table.rb
@@ -1,7 +1,7 @@
 class AddSessionsTable < ActiveRecord::Migration
   def change
     create_table :sessions do |t|
-      t.string :session_id, :null => false
+      t.string :session_id, null: false
       t.text :data
       t.timestamps
     end

--- a/db/migrate/20140227154306_create_host_paths.rb
+++ b/db/migrate/20140227154306_create_host_paths.rb
@@ -9,8 +9,8 @@ class CreateHostPaths < ActiveRecord::Migration
       t.references :mapping
     end
 
-    add_index :host_paths, [:host_id, :path_hash], unique: true # Used only for uniqueness inserting
-    add_index :host_paths, :c14n_path_hash                      # Used for lookup when creating/editing mappings
+    add_index :host_paths, %i[host_id path_hash], unique: true # Used only for uniqueness inserting
+    add_index :host_paths, :c14n_path_hash # Used for lookup when creating/editing mappings
     add_index :host_paths, :mapping_id
   end
 end

--- a/db/migrate/20140227154752_index_hits_on_host_id_and_path_hash.rb
+++ b/db/migrate/20140227154752_index_hits_on_host_id_and_path_hash.rb
@@ -1,5 +1,5 @@
 class IndexHitsOnHostIdAndPathHash < ActiveRecord::Migration
   def change
-    add_index :hits, [:host_id, :path_hash]
+    add_index :hits, %i[host_id path_hash]
   end
 end

--- a/db/migrate/20140404112839_create_organisations_sites.rb
+++ b/db/migrate/20140404112839_create_organisations_sites.rb
@@ -5,6 +5,6 @@ class CreateOrganisationsSites < ActiveRecord::Migration
       t.references :organisation, null: false
     end
 
-    add_index :organisations_sites, [:site_id, :organisation_id], unique: true
+    add_index :organisations_sites, %i[site_id organisation_id], unique: true
   end
 end

--- a/db/migrate/20140417100412_create_mappings_batch_tables.rb
+++ b/db/migrate/20140417100412_create_mappings_batch_tables.rb
@@ -9,7 +9,7 @@ class CreateMappingsBatchTables < ActiveRecord::Migration
       t.references :site
       t.timestamps
     end
-    add_index :mappings_batches, [:user_id, :site_id]
+    add_index :mappings_batches, %i[user_id site_id]
 
     create_table :mappings_batch_entries do |t|
       t.string :path, limit: 2048

--- a/db/migrate/20140502114341_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20140502114341_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,7 +1,7 @@
 # This migration comes from acts_as_taggable_on_engine (originally 3)
 class AddTaggingsCounterCacheToTags < ActiveRecord::Migration
   def self.up
-    add_column :tags, :taggings_count, :integer, :default => 0
+    add_column :tags, :taggings_count, :integer, default: 0
 
     ActsAsTaggableOn::Tag.reset_column_information
     ActsAsTaggableOn::Tag.find_each do |tag|

--- a/db/migrate/20140507103006_create_whitelisted_hosts.rb
+++ b/db/migrate/20140507103006_create_whitelisted_hosts.rb
@@ -1,6 +1,6 @@
 class CreateWhitelistedHosts < ActiveRecord::Migration
   def change
-    create_table 'whitelisted_hosts', :force => true do |t|
+    create_table 'whitelisted_hosts', force: true do |t|
       t.string   'hostname', null: false
       t.timestamps
     end

--- a/db/migrate/20140515135431_add_type_to_mappings_tables.rb
+++ b/db/migrate/20140515135431_add_type_to_mappings_tables.rb
@@ -1,9 +1,9 @@
 class AddTypeToMappingsTables < ActiveRecord::Migration
   def change
-    add_column :mappings,         :type, :string, :null => false
+    add_column :mappings,         :type, :string, null: false
     add_column :mappings_staging, :type, :string
     add_column :mappings_batches, :type, :string
 
-    add_index "mappings", ["site_id", "type"], :name => "index_mappings_on_site_id_and_type"
+    add_index "mappings", %w[site_id type], name: "index_mappings_on_site_id_and_type"
   end
 end

--- a/db/migrate/20140520154514_set_type_from_http_status.rb
+++ b/db/migrate/20140520154514_set_type_from_http_status.rb
@@ -1,5 +1,5 @@
 class SetTypeFromHTTPStatus < ActiveRecord::Migration
-  SET_MAPPING_TYPE_FROM_HTTP_STATUS = <<-mySQL
+  SET_MAPPING_TYPE_FROM_HTTP_STATUS = <<-mySQL.freeze
     UPDATE mappings
     SET    type = (CASE http_status
                    WHEN '301' THEN 'redirect'
@@ -8,7 +8,7 @@ class SetTypeFromHTTPStatus < ActiveRecord::Migration
                    END)
   mySQL
 
-  SET_MAPPING_BATCH_TYPE_FROM_HTTP_STATUS = <<-mySQL
+  SET_MAPPING_BATCH_TYPE_FROM_HTTP_STATUS = <<-mySQL.freeze
     UPDATE mappings_batches
     SET    type = (CASE http_status
                    WHEN '301' THEN 'redirect'
@@ -21,7 +21,7 @@ class SetTypeFromHTTPStatus < ActiveRecord::Migration
     ActiveRecord::Base.connection.execute(SET_MAPPING_BATCH_TYPE_FROM_HTTP_STATUS)
   end
 
-  SET_MAPPING_HTTP_STATUS_FROM_TYPE = <<-mySQL
+  SET_MAPPING_HTTP_STATUS_FROM_TYPE = <<-mySQL.freeze
     UPDATE mappings
     SET    http_status = (CASE type
                           WHEN 'redirect' THEN '301'
@@ -30,7 +30,7 @@ class SetTypeFromHTTPStatus < ActiveRecord::Migration
                           END)
   mySQL
 
-  SET_MAPPING_BATCH_HTTP_STATUS_FROM_TYPE = <<-mySQL
+  SET_MAPPING_BATCH_HTTP_STATUS_FROM_TYPE = <<-mySQL.freeze
     UPDATE mappings_batches
     SET    http_status = (CASE type
                           WHEN 'redirect' THEN '301'

--- a/db/migrate/20140523100338_remove_http_status_from_mappings_tables.rb
+++ b/db/migrate/20140523100338_remove_http_status_from_mappings_tables.rb
@@ -1,6 +1,6 @@
 class RemoveHTTPStatusFromMappingsTables < ActiveRecord::Migration
   def up
-    remove_index :mappings, [:site_id, :http_status]
+    remove_index :mappings, %i[site_id http_status]
 
     remove_column :mappings,         :http_status
     remove_column :mappings_staging, :http_status
@@ -12,6 +12,6 @@ class RemoveHTTPStatusFromMappingsTables < ActiveRecord::Migration
     add_column :mappings_staging, :http_status, :string
     add_column :mappings_batches, :http_status, :string
 
-    add_index "mappings", ["site_id", "http_status"], :name => "index_mappings_on_site_id_and_http_status"
+    add_index "mappings", %w[site_id http_status], name: "index_mappings_on_site_id_and_http_status"
   end
 end

--- a/db/migrate/20140529130515_set_global_type_from_global_http_status.rb
+++ b/db/migrate/20140529130515_set_global_type_from_global_http_status.rb
@@ -1,5 +1,5 @@
 class SetGlobalTypeFromGlobalHTTPStatus < ActiveRecord::Migration
-  SET_GLOBAL_TYPE_FROM_GLOBAL_HTTP_STATUS = <<-mySQL
+  SET_GLOBAL_TYPE_FROM_GLOBAL_HTTP_STATUS = <<-mySQL.freeze
     UPDATE sites
     SET    global_type = (CASE global_http_status
                           WHEN '301' THEN 'redirect'
@@ -12,7 +12,7 @@ class SetGlobalTypeFromGlobalHTTPStatus < ActiveRecord::Migration
     ActiveRecord::Base.connection.execute(SET_GLOBAL_TYPE_FROM_GLOBAL_HTTP_STATUS)
   end
 
-  SET_GLOBAL_HTTP_STATUS_FROM_GLOBAL_TYPE = <<-mySQL
+  SET_GLOBAL_HTTP_STATUS_FROM_GLOBAL_TYPE = <<-mySQL.freeze
     UPDATE sites
     SET    global_http_status = (CASE global_type
                                  WHEN 'redirect' THEN '301'

--- a/db/migrate/20140529164329_rename_admin_permission_to_gds_editor.rb
+++ b/db/migrate/20140529164329_rename_admin_permission_to_gds_editor.rb
@@ -5,14 +5,14 @@ class RenameAdminPermissionToGdsEditor < ActiveRecord::Migration
 
   def up
     User.where("permissions like '%admin%'").each do |user|
-      user.permissions = user.permissions.map { |string| (string == 'admin') ? 'GDS Editor' : string }
+      user.permissions = user.permissions.map { |string| string == 'admin' ? 'GDS Editor' : string }
       user.save
     end
   end
 
   def down
     User.where("permissions like '%GDS Editor%'").each do |user|
-      user.permissions = user.permissions.map { |string| (string == 'GDS Editor') ? 'admin' : string }
+      user.permissions = user.permissions.map { |string| string == 'GDS Editor' ? 'admin' : string }
       user.save
     end
   end

--- a/db/migrate/20140606155408_create_taggings_index_on_type_and_id.rb
+++ b/db/migrate/20140606155408_create_taggings_index_on_type_and_id.rb
@@ -1,5 +1,5 @@
 class CreateTaggingsIndexOnTypeAndId < ActiveRecord::Migration
   def change
-    add_index :taggings, [:taggable_type, :taggable_id]
+    add_index :taggings, %i[taggable_type taggable_id]
   end
 end

--- a/db/migrate/20140611144610_fix_collation_woes.rb
+++ b/db/migrate/20140611144610_fix_collation_woes.rb
@@ -5,6 +5,5 @@ class FixCollationWoes < ActiveRecord::Migration
     # have a migration record in the database without a matching file.
   end
 
-  def down
-  end
+  def down; end
 end

--- a/db/migrate/20140618092821_remove_global_http_status_column.rb
+++ b/db/migrate/20140618092821_remove_global_http_status_column.rb
@@ -4,6 +4,6 @@ class RemoveGlobalHTTPStatusColumn < ActiveRecord::Migration
   end
 
   def down
-    add_column :sites, :global_http_status, :string, :limit => 3
+    add_column :sites, :global_http_status, :string, limit: 3
   end
 end

--- a/db/migrate/20140618145219_add_hit_count_to_mappings.rb
+++ b/db/migrate/20140618145219_add_hit_count_to_mappings.rb
@@ -3,5 +3,4 @@ class AddHitCountToMappings < ActiveRecord::Migration
     add_column :mappings, :hit_count, :integer
     add_index :mappings, :hit_count
   end
-
 end

--- a/db/migrate/20140708144520_rationalise_hits_indices.rb
+++ b/db/migrate/20140708144520_rationalise_hits_indices.rb
@@ -15,26 +15,26 @@ class RationaliseHitsIndices < ActiveRecord::Migration
   #
   # Strip things back to what we do require.
   def up
-    remove_index_if_exists :hits, [:host_id, :hit_on]
-    remove_index_if_exists :hits, [:host_id, :http_status]
-    remove_index_if_exists :hits, [:host_id, :path_hash, :hit_on, :http_status]
-    remove_index_if_exists :hits, [:host_id, :path_hash]
+    remove_index_if_exists :hits, %i[host_id hit_on]
+    remove_index_if_exists :hits, %i[host_id http_status]
+    remove_index_if_exists :hits, %i[host_id path_hash hit_on http_status]
+    remove_index_if_exists :hits, %i[host_id path_hash]
     remove_index_if_exists :hits, [:host_id]
     remove_index_if_exists :hits, [:path_hash]
 
-    add_index_unless_exists :hits, [:host_id, :path, :hit_on, :http_status], unique: true
-    add_index_unless_exists :hits, [:host_id, :hit_on, :http_status]
+    add_index_unless_exists :hits, %i[host_id path hit_on http_status], unique: true
+    add_index_unless_exists :hits, %i[host_id hit_on http_status]
   end
 
   def down
-    add_index :hits, [:host_id, :hit_on]
-    add_index :hits, [:host_id, :http_status]
-    add_index :hits, [:host_id, :path_hash, :hit_on, :http_status], unique: true
-    add_index :hits, [:host_id, :path_hash]
+    add_index :hits, %i[host_id hit_on]
+    add_index :hits, %i[host_id http_status]
+    add_index :hits, %i[host_id path_hash hit_on http_status], unique: true
+    add_index :hits, %i[host_id path_hash]
     add_index :hits, [:host_id]
     add_index :hits, [:path_hash]
 
-    remove_index_if_exists :hits, column: [:host_id, :path, :hit_on, :http_status]
-    remove_index_if_exists :hits, column: [:host_id, :hit_on, :http_status]
+    remove_index_if_exists :hits, column: %i[host_id path hit_on http_status]
+    remove_index_if_exists :hits, column: %i[host_id hit_on http_status]
   end
 end

--- a/db/migrate/20140911113424_delete_absolute_filename_imported_hits_files.rb
+++ b/db/migrate/20140911113424_delete_absolute_filename_imported_hits_files.rb
@@ -4,6 +4,5 @@ class DeleteAbsoluteFilenameImportedHitsFiles < ActiveRecord::Migration
     ActiveRecord::Base.connection.execute(command)
   end
 
-  def down
-  end
+  def down; end
 end

--- a/db/migrate/20140922152625_remove_managed_by_transition_column.rb
+++ b/db/migrate/20140922152625_remove_managed_by_transition_column.rb
@@ -4,6 +4,6 @@ class RemoveManagedByTransitionColumn < ActiveRecord::Migration
   end
 
   def down
-    add_column :sites, :managed_by_transition, :boolean, :null => false, :default => true
+    add_column :sites, :managed_by_transition, :boolean, null: false, default: true
   end
 end

--- a/db/migrate/20140924105220_compromise_indices_for9_1.rb
+++ b/db/migrate/20140924105220_compromise_indices_for9_1.rb
@@ -20,14 +20,14 @@ class CompromiseIndicesFor91 < ActiveRecord::Migration
   end
 
   def up
-    remove_index_if_exists  :hits, [:host_id, :hit_on, :http_status]
-    add_index_unless_exists :hits, [:host_id, :hit_on]
-    add_index_unless_exists :hits, [:host_id, :http_status]
+    remove_index_if_exists  :hits, %i[host_id hit_on http_status]
+    add_index_unless_exists :hits, %i[host_id hit_on]
+    add_index_unless_exists :hits, %i[host_id http_status]
   end
 
   def down
-    remove_index_if_exists :hits,  [:host_id, :hit_on]
-    remove_index_if_exists :hits,  [:host_id, :http_status]
-    add_index_unless_exists :hits, [:host_id, :hit_on, :http_status]
+    remove_index_if_exists :hits,  %i[host_id hit_on]
+    remove_index_if_exists :hits,  %i[host_id http_status]
+    add_index_unless_exists :hits, %i[host_id hit_on http_status]
   end
 end

--- a/db/migrate/20141103142639_index_site_mappings_by_path.rb
+++ b/db/migrate/20141103142639_index_site_mappings_by_path.rb
@@ -1,5 +1,5 @@
 class IndexSiteMappingsByPath < ActiveRecord::Migration
   def change
-    add_index :mappings, [:site_id, :path], unique: true
+    add_index :mappings, %i[site_id path], unique: true
   end
 end

--- a/db/migrate/20141114110930_populate_host_paths_canonical_path.rb
+++ b/db/migrate/20141114110930_populate_host_paths_canonical_path.rb
@@ -11,11 +11,11 @@ class PopulateHostPathsCanonicalPath < ActiveRecord::Migration
     start_time = Time.zone.now
 
     host_paths = HostPath.all
-      .joins(:host => :site)
-      .includes(:host => :site)
+      .joins(host: :site)
+      .includes(host: :site)
       .where(canonical_path: nil)
 
-    $stderr.puts "Populating canonical paths on #{total_records} records"
+    warn "Populating canonical paths on #{total_records} records"
     host_paths.find_in_batches(batch_size: batch_size) do |host_paths|
       host_paths.each do |host_path|
         site = host_path.host.site
@@ -26,7 +26,7 @@ class PopulateHostPathsCanonicalPath < ActiveRecord::Migration
       elapsed_time = Time.zone.now - start_time
 
       time_remaining = elapsed_time * (total_records - record_offset) / record_offset
-      $stderr.puts "Updated #{record_offset} / #{total_records} (#{distance_of_time_in_words(time_remaining)} remaining)"
+      warn "Updated #{record_offset} / #{total_records} (#{distance_of_time_in_words(time_remaining)} remaining)"
     end
   end
 

--- a/db/migrate/20141118112125_stop_using_path_hash.rb
+++ b/db/migrate/20141118112125_stop_using_path_hash.rb
@@ -5,8 +5,8 @@
 # * drop NOT NULL constraints on all `path_hash` fields
 class StopUsingPathHash < ActiveRecord::Migration
   def up
-    remove_index :host_paths, column: [:host_id, :path_hash]
-    add_index :host_paths, [:host_id, :path], unique: true
+    remove_index :host_paths, column: %i[host_id path_hash]
+    add_index :host_paths, %i[host_id path], unique: true
 
     # Make the mappings and hits path hashes unimportant to our new code,
     # but still present to any extant processes needing access
@@ -24,7 +24,7 @@ class StopUsingPathHash < ActiveRecord::Migration
   #
   # As a result, +raise ActiveRecord::IrreversibleMigration+ or convert this
   # SQL to Ruby following initial deploy.
-  BACKFILL_PATH_HASH_NULLS = <<-postgreSQL
+  BACKFILL_PATH_HASH_NULLS = <<-postgreSQL.freeze
     UPDATE hits
     SET    path_hash = (encode(digest(hits.path, 'sha1'), 'hex'))
     WHERE  hits.path_hash IS NULL;
@@ -35,8 +35,8 @@ class StopUsingPathHash < ActiveRecord::Migration
   postgreSQL
 
   def down
-    remove_index :host_paths, column: [:host_id, :path]
-    add_index :host_paths, [:host_id, :path_hash], unique: true
+    remove_index :host_paths, column: %i[host_id path]
+    add_index :host_paths, %i[host_id path_hash], unique: true
 
     # Fill in any blanks in hits/mappings that can't be NULL
     execute(BACKFILL_PATH_HASH_NULLS)

--- a/db/migrate/20141119113045_drop_path_hash.rb
+++ b/db/migrate/20141119113045_drop_path_hash.rb
@@ -15,6 +15,6 @@ class DropPathHash < ActiveRecord::Migration
     add_column :host_paths, :path_hash,      :string
     add_column :host_paths, :c14n_path_hash, :string
 
-    add_index :mappings, [:site_id, :path_hash]
+    add_index :mappings, %i[site_id path_hash]
   end
 end

--- a/db/migrate/20150320164433_remove_individual_nhsuk_domains_from_whitelist.rb
+++ b/db/migrate/20150320164433_remove_individual_nhsuk_domains_from_whitelist.rb
@@ -1,8 +1,6 @@
 class RemoveIndividualNhsukDomainsFromWhitelist < ActiveRecord::Migration
   def up
-    WhitelistedHost.where("hostname LIKE '%.nhs.uk'").each do |whitelisted_host|
-      whitelisted_host.destroy
-    end
+    WhitelistedHost.where("hostname LIKE '%.nhs.uk'").each(&:destroy)
   end
 
   def down

--- a/db/migrate/20150428155430_remove_fake_organisations.rb
+++ b/db/migrate/20150428155430_remove_fake_organisations.rb
@@ -7,8 +7,9 @@ class RemoveFakeOrganisations < ActiveRecord::Migration
   end
 
   def up
-    Organisation.where(whitehall_slug: ['directgov', 'business-link']).each do |organisation|
+    Organisation.where(whitehall_slug: %w[directgov business-link]).each do |organisation|
       raise "Won't delete organisation with sites" if organisation.sites.any?
+
       organisation.delete
     end
   end

--- a/db/migrate/20160314150052_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20160314150052_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,10 +1,10 @@
 # This migration comes from acts_as_taggable_on_engine (originally 4)
 class AddMissingTaggableIndex < ActiveRecord::Migration
   def self.up
-    add_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings, %i[taggable_id taggable_type context]
   end
 
   def self.down
-    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    remove_index :taggings, %i[taggable_id taggable_type context]
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,7 +5,7 @@ if Rails.env.development?
     u             = User.new
     u.email       = "test@example.com"
     u.name        = "Test User"
-    u.permissions = ["signin", "admin"]
+    u.permissions = %w[signin admin]
     u.organisation_content_id = '96ae61d6-c2a1-48cb-8e67-da9d105ae381'
     u.save
   end

--- a/features/step_definitions/fixture_steps.rb
+++ b/features/step_definitions/fixture_steps.rb
@@ -53,12 +53,11 @@ Given(/^there is a site called (.*) belonging to an organisation (.*) with these
 
   site.mappings = mappings_table.rows.map do |type, path, new_url, tags|
     create(:mapping,
-      site: site,
-      type: type,
-      path: path,
-      new_url: new_url == '' ? nil : new_url,
-      tag_list: tags
-    )
+           site: site,
+           type: type,
+           path: path,
+           new_url: new_url == '' ? nil : new_url,
+           tag_list: tags)
   end
 end
 
@@ -71,7 +70,7 @@ Given (/^a(?:n) (\w+) mapping exists for the site with the path (.*)$/) do |type
   @site.mappings << create(:mapping, type: type, path: path)
 end
 
-Given(/^there is an organisation with the whitehall_slug "(.*?)"$/) do |abbr|
+Given(/^there is an organisation with the whitehall_slug "(.*?)"$/) do |_abbr|
   @organisation = create(:organisation, whitehall_slug: "ukaea")
 end
 

--- a/features/step_definitions/general_configuration_steps.rb
+++ b/features/step_definitions/general_configuration_steps.rb
@@ -2,9 +2,11 @@
 # This should be called no more than once per scenario
 Given(/^the (.*) page size is ([0-9]+)$/) do |class_name, page_size|
   klass = Object.const_get(class_name.singularize.capitalize)
-  raise ArgumentError.new(
-    "Page size has already been set for #{klass} in current Scenario"
-  ) if @klass_old_page_sizes && @klass_old_page_sizes[klass]
+  if @klass_old_page_sizes && @klass_old_page_sizes[klass]
+    raise ArgumentError.new(
+      "Page size has already been set for #{klass} in current Scenario"
+    )
+  end
 
   klass_old_page_sizes = @klass_old_page_sizes || {}
 

--- a/features/step_definitions/hits_assertion_steps.rb
+++ b/features/step_definitions/hits_assertion_steps.rb
@@ -50,7 +50,6 @@ Then(/^I should see a section for the most common (\w+)$/) do |category|
 end
 
 Then(/^it should show(?: only the top) (\d+) (\w+) in descending count order$/) do |count, category|
-
   case category
   when 'errors'
     status = 404
@@ -84,7 +83,6 @@ Then(/^I should see a trend for all hits, errors, archives and redirects$/) do
 end
 
 Then(/^I should see hits from the last 30 days with a[n]? (\w+) status, in descending count order$/) do |category|
-
   case category
   when 'error'
     status = 404
@@ -100,7 +98,6 @@ Then(/^I should see hits from the last 30 days with a[n]? (\w+) status, in desce
 end
 
 Then(/^I should see all hits with a[n]? (\w+) status, in descending count order$/) do |category|
-
   case category
   when 'error'
     status = 404
@@ -145,15 +142,14 @@ Then(/^the top hit's canonicalized path should already be in the form$/) do
 end
 
 Then(/^I should see a[n]? (\w+) graph showing a (\w+) trend line(?: with )?([0-9]*)?(?: points)?$/) do |category, color, points|
-
-  case color
-  when 'red'
-    color = '#ee9999'
-  when 'green'
-    color = '#99ee99'
-  else
-    color = '#aaaaaa'
-  end
+  color = case color
+          when 'red'
+            '#ee9999'
+          when 'green'
+            '#99ee99'
+          else
+            '#aaaaaa'
+          end
 
   expect(page).to have_selector('.hits-graph svg text', text: category.titleize)
   expect(page).to have_selector(".hits-graph svg path[stroke='#{color}']")

--- a/features/step_definitions/hits_fixtures_steps.rb
+++ b/features/step_definitions/hits_fixtures_steps.rb
@@ -11,11 +11,10 @@ Given(/^some hits for the Attorney General's site have mappings and some don't:$
                  path: path,
                  mapping: mapping
   end
-
 end
 
 Given(/^some hits exist for the Attorney General, Cabinet Office and FCO sites:$/) do |table|
-  ['ago', 'cabinet-office', 'fco'].each do |abbr|
+  %w[ago cabinet-office fco].each do |abbr|
     site = create(:site, abbr: abbr)
     # table is a | 410         | /    | 16/10/12 | 100   |
     table.rows.map do |status, path, hit_on, count|

--- a/features/step_definitions/mappings_assertion_steps.rb
+++ b/features/step_definitions/mappings_assertion_steps.rb
@@ -156,20 +156,20 @@ Then(/^I should see the canonicalized paths "(.*?)"$/) do |paths|
 end
 
 Then(/^I should see the tags "([^"]*)"$/) do |tag_list|
-  if @_javascript
-    field = find(:xpath, '//input[contains(@class, "select2-offscreen")]')
-  else
-    field = find_field('Tags')
-  end
+  field = if @_javascript
+            find(:xpath, '//input[contains(@class, "select2-offscreen")]')
+          else
+            find_field('Tags')
+          end
 
   expected_values = tag_list.split(/\s*,\s*/)
-  field_values  = field.value.split(/\s*,\s*/)
+  field_values = field.value.split(/\s*,\s*/)
 
   expect(field_values).to match_array(expected_values)
 end
 
 Then(/^I should see that all were tagged "([^"]*)"$/) do |tag_list|
-  within '.alert-success', :match => :first do
+  within '.alert-success', match: :first do
     expect(page).to have_content(
       %(3 mappings updated and tagged with "#{tag_list}")
     )
@@ -197,7 +197,7 @@ Then(/^the mappings should all have the tags "([^"]*)"$/) do |tag_list|
 end
 
 Then(/^I should see that (\d+) were tagged "([^"]*)"$/) do |n, tag_list|
-  within '.alert-success', :match => :first do
+  within '.alert-success', match: :first do
     expect(page).to have_content(
       %(#{n} mappings tagged “#{tag_list}”)
     )
@@ -217,7 +217,7 @@ end
 Then(/^mapping (\d+) should have the tags "([^"]*)"$/) do |nth, tag_list|
   within ".mappings-index tbody tr:nth-child(#{nth}) .tag-list" do
     tag_list.split(',').map(&:strip).each do |tag|
-      expect(page).to have_selector('.tag', text:tag)
+      expect(page).to have_selector('.tag', text: tag)
     end
   end
 end
@@ -225,7 +225,7 @@ end
 Then(/^mapping (\d+) should have the tags "([^"]*)" but not "([^"]*)"$/) do |nth, tag_list, without_tag_list|
   within ".mappings-index tbody tr:nth-child(#{nth}) .tag-list" do
     tag_list.split(',').map(&:strip).each do |tag|
-      expect(page).to have_selector('.tag', text:tag)
+      expect(page).to have_selector('.tag', text: tag)
     end
     without_tag_list.split(',').map(&:strip).each do |without_tag|
       expect(page).not_to have_selector('.tag', text: without_tag)
@@ -242,13 +242,13 @@ But(/^I should not see "([^"]*)" available for selection$/) do |tag|
 end
 
 But(/^I should not see "([^"]*)" available for selection as it's already selected$/) do |tag|
-  step %Q{I should not see "#{tag}" available for selection}
+  step %{I should not see "#{tag}" available for selection}
 end
 
 Then(/^I should see the highlighted tags? "([^"]*)"$/) do |tag_list|
   within ".mappings tbody tr:first-child .tag-list" do
     tag_list.split(',').map(&:strip).each do |tag|
-      expect(page).to have_selector('.tag-active', text:tag)
+      expect(page).to have_selector('.tag-active', text: tag)
     end
   end
 end
@@ -256,7 +256,7 @@ end
 Then(/^I should see a link to remove the tags? "([^"]*)"$/) do |tag_list|
   within ".filtered-tags" do
     tag_list.split(',').map(&:strip).each do |tag|
-      expect(page).to have_selector('.tag', text:tag)
+      expect(page).to have_selector('.tag', text: tag)
     end
   end
 end

--- a/features/step_definitions/mappings_fixture_steps.rb
+++ b/features/step_definitions/mappings_fixture_steps.rb
@@ -18,7 +18,6 @@ Given(/^a site "([^"]*)" exists with mappings with lots of tags$/) do |site_abbr
       mapping.tag_list = (1..tag_count.to_i).to_a.join(', ')
     end
   end
-
 end
 
 Given(/^a site "([^"]*)" exists with these tagged mappings:$/) do |site_abbr, tagged_paths|

--- a/features/step_definitions/mappings_import_interaction_steps.rb
+++ b/features/step_definitions/mappings_import_interaction_steps.rb
@@ -20,7 +20,7 @@ When(/^I submit the form with a small valid CSV$/) do
                         /redirect-me,https://www.gov.uk/new
                         /archive-me,TNA
                         /i-dont-know-what-i-am,
-                      CSV
+  CSV
   fill_in 'import_batch_raw_csv', with: raw_csv
   click_button 'Continue'
 end
@@ -31,7 +31,7 @@ When(/^I submit the form with a small CSV of archive mappings$/) do
                         /archive-me,TNA
                         /archive-me-as-well,http://webarchive.nationalarchives.gov.uk/20120816224015/http://bis.gov.uk/about
                         /dont-forget-me,http://webarchive.nationalarchives.gov.uk/20120816224015/http://bis.gov.uk/faq
-                      CSV
+  CSV
   fill_in 'import_batch_raw_csv', with: raw_csv
   click_button 'Continue'
 end

--- a/features/step_definitions/mappings_interaction_steps.rb
+++ b/features/step_definitions/mappings_interaction_steps.rb
@@ -63,7 +63,7 @@ When(/^I open the "(.*)" filter$/) do |filter_type|
 end
 
 When(/^I open the "(.*)" filter and filter by "(.*)"$/) do |filter_type, value|
-  within ".filters#{ ' .filter-by-path' if filter_type == 'Path' }" do
+  within ".filters#{' .filter-by-path' if filter_type == 'Path'}" do
     click_link filter_type
     fill_in filter_type, with: value
     click_button 'Filter'
@@ -93,7 +93,7 @@ When(/^I filter the path by ([^"]*)$/) do |path_contains|
 end
 
 When(/^I remove the filter "(.*?)"$/) do |filter_type|
-  within ".filters#{ ' .filter-by-path' if filter_type == 'Path' }" do
+  within ".filters#{' .filter-by-path' if filter_type == 'Path'}" do
     click_link filter_type
   end
 end

--- a/features/step_definitions/page_assertion_steps.rb
+++ b/features/step_definitions/page_assertion_steps.rb
@@ -55,7 +55,8 @@ end
 
 Then(/^an automatic analytics event with "([^"]*)" will fire$/) do |contents|
   expect(page).to have_selector(
-    "[data-module='auto-track-event'][data-track-label*='#{contents}']")
+    "[data-module='auto-track-event'][data-track-label*='#{contents}']"
+)
 end
 
 # HTML structure

--- a/features/step_definitions/page_interaction_steps.rb
+++ b/features/step_definitions/page_interaction_steps.rb
@@ -11,7 +11,7 @@ When(/^I click the first (?:link|tab)(?: called)? "([^"]+)"$/) do |link_title|
 end
 
 When(/^I click the first tag(?: called)? "([^"]+)"$/) do |tag|
-  page.find('a.tag', text: tag, :match => :first).click
+  page.find('a.tag', text: tag, match: :first).click
 end
 
 When(/^I save my changes$/) do

--- a/features/step_definitions/site_fixture_steps.rb
+++ b/features/step_definitions/site_fixture_steps.rb
@@ -5,7 +5,7 @@ Given(/^(.*) site with abbr (.*) launche([s|d]) on 13\/12\/12 with the following
                  launch_date: Date.new(2012, 12, 13)
 
   # Have we launche*d*?
-  cname_trait = (launch_suffix == 'd') ? :with_govuk_cname : :with_third_party_cname
+  cname_trait = launch_suffix == 'd' ? :with_govuk_cname : :with_third_party_cname
 
   @site.hosts << create(:host, cname_trait, hostname: default_host, site: @site)
   aliases.rows.each do |hostname_row|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -55,4 +55,3 @@ end
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature
 Cucumber::Rails::Database.javascript_strategy = :truncation
-

--- a/features/support/helpers/mappings.rb
+++ b/features/support/helpers/mappings.rb
@@ -12,6 +12,7 @@ module Helpers
 
     def i_type_letters_into_tags(letters)
       raise 'Only relevant to JavaScript tests' unless @_javascript
+
       find('input.select2-input').set(letters)
     end
 
@@ -47,7 +48,7 @@ module Helpers
                             /19
                             /20
                             /21
-                          CSV
+      CSV
       fill_in 'import_batch_raw_csv', with: raw_csv
       click_button 'Continue'
     end

--- a/features/support/matchers/be_sorted.rb
+++ b/features/support/matchers/be_sorted.rb
@@ -4,7 +4,7 @@ RSpec::Matchers.define :be_sorted do
   end
 
   chain :descending do
-    @sort_block = ->(x,y) { y <=> x }
+    @sort_block = ->(x, y) { y <=> x }
   end
 
   failure_message do |array|

--- a/features/support/matchers/have_hit_counts.rb
+++ b/features/support/matchers/have_hit_counts.rb
@@ -3,8 +3,10 @@ RSpec::Matchers.define :have_hit_counts do |counts|
   include MappingsHelper
 
   match do |page|
-    raise ArgumentError,
-          "counts should be an array (got a #{counts.class})" unless counts.is_a?(Array)
+    unless counts.is_a?(Array)
+      raise ArgumentError,
+            "counts should be an array (got a #{counts.class})"
+    end
 
     within 'table.mappings tbody' do
       expect(page).to have_selector('tr', count: counts.length)

--- a/features/support/matchers/have_sorted_bar_rows.rb
+++ b/features/support/matchers/have_sorted_bar_rows.rb
@@ -1,7 +1,9 @@
 RSpec::Matchers.define :have_sorted_bar_rows do |count|
   match do |page|
-    raise RuntimeError,
-          '.for_status expected. Call like expect(page).to have_sorted_bar_rows(11).for_status(401)' unless @_status
+    unless @_status
+      raise RuntimeError,
+            '.for_status expected. Call like expect(page).to have_sorted_bar_rows(11).for_status(401)'
+    end
 
     expect(page).to have_selector('tbody tr', count: count)
     expect(page).to have_selector(".bar-chart-row-#{@_status}", count: count)

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -47,7 +47,7 @@ unless ARGV.any? { |a| a =~ /^gems/ } # Don't load anything when running the gem
     task default: :cucumber
 
     task features: :cucumber do
-      STDERR.puts "*** The 'features' task is deprecated. See rake -T cucumber ***"
+      warn "*** The 'features' task is deprecated. See rake -T cucumber ***"
     end
 
     # In case we don't have the generic Rails test:prepare hook, append a no-op task that we can depend upon.

--- a/lib/tasks/import/hits.rake
+++ b/lib/tasks/import/hits.rake
@@ -15,7 +15,7 @@ namespace :import do
   desc 'Copy filenames and etags for all old stats files from s3'
   task :update_legacy_from_s3, [:bucket] => :environment do |_, args|
     bucket = args[:bucket]
-    ['transition-stats', 'pre-transition-stats'].each do |prefix|
+    %w[transition-stats pre-transition-stats].each do |prefix|
       Services.s3.list_objects(bucket: bucket, prefix: prefix).each do |resp|
         resp.contents.each do |object|
           begin

--- a/lib/transition/distributed_lock.rb
+++ b/lib/transition/distributed_lock.rb
@@ -18,7 +18,7 @@ module Transition
     end
   end
 
-  private
+private
 
   def redis
     @_redis ||= begin

--- a/spec/assumptions_spec.rb
+++ b/spec/assumptions_spec.rb
@@ -10,8 +10,8 @@ describe 'Our assumptions' do
   # https://github.com/alphagov/transition/pull/301/files#r13339317
   it 'is necessary for performance that we only tag Mappings' do
     expect(taggable_model_classes).to eql([Mapping]),
-      'We assume only Mapping is taggable for performance reasons.'\
-      'Qualify the join in Site#most_used_tags with `AND taggable_type=\'Mapping\'`'\
-      'before you can remove this assumption.'
+                                      'We assume only Mapping is taggable for performance reasons.'\
+                                      'Qualify the join in Site#most_used_tags with `AND taggable_type=\'Mapping\'`'\
+                                      'before you can remove this assumption.'
   end
 end

--- a/spec/controllers/bulk_add_batches_controller_spec.rb
+++ b/spec/controllers/bulk_add_batches_controller_spec.rb
@@ -66,11 +66,11 @@ describe BulkAddBatchesController do
     context 'when the return path is on site' do
       it 'returns to where it came from' do
         get :preview,
-          params: {
-            site_id: site.abbr,
-            id: batch.id,
-            return_path: '/donkey'
-          }
+            params: {
+              site_id: site.abbr,
+              id: batch.id,
+              return_path: '/donkey'
+            }
 
         expect(assigns(:bulk_add_cancel_destination)).to eq('/donkey')
       end
@@ -79,11 +79,11 @@ describe BulkAddBatchesController do
     context 'when the return path is off site' do
       it 'returns to the site mappings path' do
         get :preview,
-          params: {
-            site_id: site.abbr,
-            id: batch.id,
-            return_path: 'http://google.com'
-          }
+            params: {
+              site_id: site.abbr,
+              id: batch.id,
+              return_path: 'http://google.com'
+            }
 
         expect(assigns(:bulk_add_cancel_destination)).to eq(site_mappings_path(site.abbr))
       end
@@ -123,11 +123,11 @@ describe BulkAddBatchesController do
       context 'a small batch' do
         def make_request
           post :import,
-            params: {
-              site_id: site.abbr,
-              update_existing: 'true',
-              id: batch.id
-            }
+               params: {
+                 site_id: site.abbr,
+                 update_existing: 'true',
+                 id: batch.id
+               }
         end
 
         include_examples 'it processes a small batch inline'
@@ -142,11 +142,11 @@ describe BulkAddBatchesController do
 
         def make_request
           post :import,
-            params: {
-              site_id: site.abbr,
-              update_existing: 'true',
-              id: large_batch.id
-            }
+               params: {
+                 site_id: site.abbr,
+                 update_existing: 'true',
+                 id: large_batch.id
+               }
         end
 
         include_examples 'it processes a large batch in the background'
@@ -212,11 +212,11 @@ describe BulkAddBatchesController do
     context '#import' do
       it 'should redirect to mappings index' do
         post :import,
-          params: {
-            site_id: site.abbr,
-            id: batch.id,
-            return_path: 'http://malicious.com'
-          }
+             params: {
+               site_id: site.abbr,
+               id: batch.id,
+               return_path: 'http://malicious.com'
+             }
         expect(response).to redirect_to site_mappings_path(site)
       end
     end

--- a/spec/controllers/import_batches_controller_spec.rb
+++ b/spec/controllers/import_batches_controller_spec.rb
@@ -54,13 +54,13 @@ describe ImportBatchesController do
       let(:long_url)          { "#{stem}#{'x' * (2048 - stem.length)}" }
       before do
         post :create,
-          params: {
-            site_id: site.abbr,
-            import_batch: {
-              raw_csv: "/a,TNA\n/b,#{long_url}",
-              tag_list: ''
-            }
-          }
+             params: {
+               site_id: site.abbr,
+               import_batch: {
+                 raw_csv: "/a,TNA\n/b,#{long_url}",
+                 tag_list: ''
+               }
+             }
       end
 
       it 'creates a batch for the site' do
@@ -115,12 +115,12 @@ describe ImportBatchesController do
     context 'with invalid parameters' do
       before do
         post :create,
-          params: {
-            site_id: site.abbr,
-            import_batch: {
-              raw_csv: 'a,', tag_list: ''
-            }
-          }
+             params: {
+               site_id: site.abbr,
+               import_batch: {
+                 raw_csv: 'a,', tag_list: ''
+               }
+             }
       end
 
       it 'does not create a batch for the site' do
@@ -189,11 +189,11 @@ describe ImportBatchesController do
     context 'a small batch' do
       def make_request
         post :import,
-          params: {
-            site_id: site.abbr,
-            import_batch: { update_existing: 'true' },
-            id: batch.id
-          }
+             params: {
+               site_id: site.abbr,
+               import_batch: { update_existing: 'true' },
+               id: batch.id
+             }
       end
 
       include_examples 'it processes a small batch inline'
@@ -204,11 +204,11 @@ describe ImportBatchesController do
 
       def make_request
         post :import,
-          params: {
-            site_id: site.abbr,
-            import_batch: { update_existing: 'true' },
-            id: large_batch.id
-          }
+             params: {
+               site_id: site.abbr,
+               import_batch: { update_existing: 'true' },
+               id: large_batch.id
+             }
       end
 
       include_examples 'it processes a large batch in the background'

--- a/spec/controllers/mappings_controller_spec.rb
+++ b/spec/controllers/mappings_controller_spec.rb
@@ -271,14 +271,14 @@ describe MappingsController do
         before do
           login_as gds_bob
           post :update,
-            params: {
-              site_id: mapping.site,
-              id: mapping.id,
-              mapping: {
-                path: '/Needs/Canonicalization?has=some&query=parts',
-                new_url: 'http://a.gov.uk'
-              }
-            }
+               params: {
+                 site_id: mapping.site,
+                 id: mapping.id,
+                 mapping: {
+                   path: '/Needs/Canonicalization?has=some&query=parts',
+                   new_url: 'http://a.gov.uk'
+                 }
+               }
         end
 
         it 'canonicalizes the path' do
@@ -305,15 +305,15 @@ describe MappingsController do
       before do
         login_as gds_bob
         post :update,
-          params: {
-            site_id: mapping.site,
-            id: mapping.id,
-            mapping: {
-              path: '/Needs/Canonicalization?has=some&query=parts',
-              new_url: 'http://somewhere.gov.uk',
-              tag_list: 'fEE, fI, fO'
-             }
-           }
+             params: {
+               site_id: mapping.site,
+               id: mapping.id,
+               mapping: {
+                 path: '/Needs/Canonicalization?has=some&query=parts',
+                 new_url: 'http://somewhere.gov.uk',
+                 tag_list: 'fEE, fI, fO'
+                }
+              }
       end
 
       subject(:tags_as_strings) { mapping.reload.tags.map(&:to_s) }
@@ -337,12 +337,12 @@ describe MappingsController do
       def make_request
         mapping_ids = [mapping_a.id, mapping_b.id]
         post :edit_multiple,
-          params: {
-            site_id: site.abbr,
-            mapping_ids: mapping_ids,
-            type: 'archive',
-            return_path: @mappings_index_with_filter
-          }
+             params: {
+               site_id: site.abbr,
+               mapping_ids: mapping_ids,
+               type: 'archive',
+               return_path: @mappings_index_with_filter
+             }
       end
 
       it_behaves_like 'disallows editing by unaffiliated user'
@@ -358,11 +358,11 @@ describe MappingsController do
       context 'when the mappings index has not been visited' do
         it 'redirects to the mappings index page' do
           post :edit_multiple,
-            params: {
-              site_id: site.abbr,
-              mapping_ids: [other_mapping.id],
-              type: 'archive'
-            }
+               params: {
+                 site_id: site.abbr,
+                 mapping_ids: [other_mapping.id],
+                 type: 'archive'
+               }
 
           expect(response).to redirect_to site_mappings_path(site)
         end
@@ -371,12 +371,12 @@ describe MappingsController do
       context 'when coming from the mappings index with a path filter' do
         it 'redirects back to the last-visited mappings index page' do
           post :edit_multiple,
-            params: {
-              site_id: site.abbr,
-              mapping_ids: [other_mapping.id],
-              type: 'archive',
-              return_path: @mappings_index_with_filter
-            }
+               params: {
+                 site_id: site.abbr,
+                 mapping_ids: [other_mapping.id],
+                 type: 'archive',
+                 return_path: @mappings_index_with_filter
+               }
 
           expect(response).to redirect_to @mappings_index_with_filter
         end
@@ -392,12 +392,12 @@ describe MappingsController do
         it 'redirects back to the last-visited mappings index page' do
           mapping_ids = [mapping_a.id, mapping_b.id]
           post :edit_multiple,
-            params: {
-              site_id: site.abbr,
-              mapping_ids: mapping_ids,
-              type: 'bad',
-              return_path: @mappings_index_with_filter
-            }
+               params: {
+                 site_id: site.abbr,
+                 mapping_ids: mapping_ids,
+                 type: 'bad',
+                 return_path: @mappings_index_with_filter
+               }
 
           expect(response).to redirect_to @mappings_index_with_filter
         end
@@ -410,12 +410,12 @@ describe MappingsController do
       before do
         login_as gds_bob
         post :edit_multiple,
-          params: {
-            site_id: site.abbr,
-            mapping_ids: mapping_ids,
-            operation: 'tag',
-            return_path: 'should_not_return'
-          }
+             params: {
+               site_id: site.abbr,
+               mapping_ids: mapping_ids,
+               operation: 'tag',
+               return_path: 'should_not_return'
+             }
       end
 
       it 'shows the tagging page' do
@@ -437,12 +437,12 @@ describe MappingsController do
       def make_request
         mapping_ids = [mapping_a.id, mapping_b.id]
         post :update_multiple,
-          params: {
-            site_id: site.abbr,
-            mapping_ids: mapping_ids,
-            operation: 'redirect',
-            new_url: 'http://a.gov.uk'
-          }
+             params: {
+               site_id: site.abbr,
+               mapping_ids: mapping_ids,
+               operation: 'redirect',
+               new_url: 'http://a.gov.uk'
+             }
       end
 
       it_behaves_like 'disallows editing by unaffiliated user'
@@ -461,13 +461,13 @@ describe MappingsController do
         mapping_ids = [mapping_a.id, mapping_b.id]
         @new_url = 'http://a.gov.uk'
         post :update_multiple,
-          params: {
-            site_id: site.abbr,
-            mapping_ids: mapping_ids,
-            operation: 'redirect',
-            new_url: @new_url,
-            return_path: @mappings_index_with_filter
-          }
+             params: {
+               site_id: site.abbr,
+               mapping_ids: mapping_ids,
+               operation: 'redirect',
+               new_url: @new_url,
+               return_path: @mappings_index_with_filter
+             }
       end
 
       it 'updates the mappings correctly' do
@@ -507,12 +507,12 @@ describe MappingsController do
       context 'when the mappings index has not been visited' do
         it 'redirects to the mappings index page' do
           post :update_multiple,
-            params: {
-              site_id: site.abbr,
-              mapping_ids: [other_mapping.id],
-              type: 'redirect',
-              new_url: 'http://a.gov.uk'
-            }
+               params: {
+                 site_id: site.abbr,
+                 mapping_ids: [other_mapping.id],
+                 type: 'redirect',
+                 new_url: 'http://a.gov.uk'
+               }
 
           expect(response).to redirect_to site_mappings_path(site)
         end
@@ -521,13 +521,13 @@ describe MappingsController do
       context 'when the mappings index was last visited with a path filter' do
         it 'redirects back to the last-visited mappings index page' do
           post :update_multiple,
-            params: {
-              site_id: site.abbr,
-              mapping_ids: [other_mapping.id],
-              type: 'redirect',
-              new_url: 'http://a.gov.uk',
-              return_path: @mappings_index_with_filter
-            }
+               params: {
+                 site_id: site.abbr,
+                 mapping_ids: [other_mapping.id],
+                 type: 'redirect',
+                 new_url: 'http://a.gov.uk',
+                 return_path: @mappings_index_with_filter
+               }
 
           expect(response).to redirect_to @mappings_index_with_filter
         end
@@ -539,12 +539,12 @@ describe MappingsController do
         login_as gds_bob
         mapping_ids = [mapping_a.id, mapping_b.id]
         post :update_multiple,
-          params: {
-            site_id: site.abbr,
-            mapping_ids: mapping_ids,
-            type: 'redirect',
-            new_url: 'http://{'
-          }
+             params: {
+               site_id: site.abbr,
+               mapping_ids: mapping_ids,
+               type: 'redirect',
+               new_url: 'http://{'
+             }
       end
 
       it 'does not update any mappings' do
@@ -620,11 +620,11 @@ describe MappingsController do
       # in order to test our override of the verify_authenticity_token method
       allow(subject).to receive(:verified_request?).and_return(false)
       post :update,
-        params: {
-          site_id: mapping.site,
-          id: mapping.id,
-          mapping: { path: '/foo' }
-        }
+           params: {
+             site_id: mapping.site,
+             id: mapping.id,
+             mapping: { path: '/foo' }
+           }
 
       expect(response.status).to eql(403)
     end
@@ -638,15 +638,15 @@ describe MappingsController do
     context 'update' do
       it 'should redirect to mappings index' do
         post :update,
-          params: {
-            site_id: mapping.site,
-            id: mapping.id,
-            mapping: {
-              path: '/Needs/Canonicalization?has=some&query=parts',
-              new_url: 'http://a.gov.uk'
-            },
-            return_path: 'http://malicious.com'
-          }
+             params: {
+               site_id: mapping.site,
+               id: mapping.id,
+               mapping: {
+                 path: '/Needs/Canonicalization?has=some&query=parts',
+                 new_url: 'http://a.gov.uk'
+               },
+               return_path: 'http://malicious.com'
+             }
 
         expect(response).to redirect_to site_mappings_path(site)
       end
@@ -657,13 +657,13 @@ describe MappingsController do
 
       it 'should redirect to mappings index' do
         post :update_multiple,
-          params: {
-            site_id: site.abbr,
-            mapping_ids: [mapping.id],
-            operation: 'redirect',
-            new_url: 'http://a.gov.uk',
-            return_path: 'http://malicious.com'
-          }
+             params: {
+               site_id: site.abbr,
+               mapping_ids: [mapping.id],
+               operation: 'redirect',
+               new_url: 'http://a.gov.uk',
+               return_path: 'http://malicious.com'
+             }
 
         expect(response).to redirect_to site_mappings_path(site)
       end

--- a/spec/lib/transition/import/whitehall_orgs_spec.rb
+++ b/spec/lib/transition/import/whitehall_orgs_spec.rb
@@ -39,7 +39,7 @@ describe Transition::Import::WhitehallOrgs do
 
     context 'when there are some organisations in the API' do
       before do
-        organisations_api_has_organisations ['ministry-of-funk', 'department-of-soul', 'hm-rock-and-roll']
+        organisations_api_has_organisations %w[ministry-of-funk department-of-soul hm-rock-and-roll]
       end
 
       it 'extracts all the organisations from the API' do
@@ -50,14 +50,14 @@ describe Transition::Import::WhitehallOrgs do
     context 'when there are so many organisations in the API that it paginates' do
       before do
         # The default pagination is 20, so make 21 to trigger this
-        organisations_api_has_organisations [
-          'ministry-of-funk-1', 'department-of-soul-1', 'hm-rock-and-roll-1',
-          'ministry-of-funk-2', 'department-of-soul-2', 'hm-rock-and-roll-2',
-          'ministry-of-funk-3', 'department-of-soul-3', 'hm-rock-and-roll-3',
-          'ministry-of-funk-4', 'department-of-soul-4', 'hm-rock-and-roll-4',
-          'ministry-of-funk-5', 'department-of-soul-5', 'hm-rock-and-roll-5',
-          'ministry-of-funk-6', 'department-of-soul-6', 'hm-rock-and-roll-6',
-          'ministry-of-funk-7', 'department-of-soul-7', 'hm-rock-and-roll-7',
+        organisations_api_has_organisations %w[
+          ministry-of-funk-1 department-of-soul-1 hm-rock-and-roll-1
+          ministry-of-funk-2 department-of-soul-2 hm-rock-and-roll-2
+          ministry-of-funk-3 department-of-soul-3 hm-rock-and-roll-3
+          ministry-of-funk-4 department-of-soul-4 hm-rock-and-roll-4
+          ministry-of-funk-5 department-of-soul-5 hm-rock-and-roll-5
+          ministry-of-funk-6 department-of-soul-6 hm-rock-and-roll-6
+          ministry-of-funk-7 department-of-soul-7 hm-rock-and-roll-7
         ]
       end
 


### PR DESCRIPTION
* Existing rake command calls `lint`. This results in `bundle exec govuk-lint-ruby`. It makes sense to me to keep using the existing linter even though it may differ from the dxw styleguide.
* This has been generated using `bundle exec govuk-lint-ruby --auto-correct`