### PR TITLE
(fix) Site form field reordering

### DIFF
--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -36,16 +36,16 @@
       <fieldset class="form-group row">
         <div class="col-md-6">
           <%= f.label :launch_date, 'New transition date' %>
-          <%= f.text_field :launch_date, :class => 'form-control' %>
+          <%= f.date_select(:launch_date,
+                              { order: [:day, :month, :year]},
+                              { class: 'form-control date' }) %>
         </div>
       </fieldset>
 
       <fieldset class="form-group row">
         <div class="col-md-6">
           <%= f.label :global_new_url %>
-          <%= f.date_select(:launch_date,
-                              { order: [:day, :month, :year]},
-                              { class: 'form-control date' }) %>
+          <%= f.text_field :global_new_url, :class => 'form-control' %>
         </div>
       </fieldset>
 


### PR DESCRIPTION
* There was a mistake made where the inputs didn't match the labels. This meant that a new host record could not be made from the global_new_url field.
* Wrongly assumed that there would be test coverage in the ~1000 feature tests to catch this error.