### PR TITLE
(fix) Guard W3C parsing against unexpected files

### DIFF
--- a/lib/transition/import/hits.rb
+++ b/lib/transition/import/hits.rb
@@ -171,13 +171,15 @@ module Transition
           file.each_line do |combined_log_line|
             log = IISAccessLogParser::Entry.from_string(combined_log_line)
 
-            parsed_log_lines << [
-              log.date.to_date.to_s,
-              nil, # Set this position in the array for updating the count later
+            parsed_log_line = [
+              log.date&.to_date&.to_s,
+              0, # Set this position in the array for updating the count later
               log.status,
               log.host,
               log.url
             ]
+
+            parsed_log_lines << parsed_log_line unless parsed_log_line.any?(nil)
           end
         end
 

--- a/spec/fixtures/hits/unexpected_log_format.log
+++ b/spec/fixtures/hits/unexpected_log_format.log
@@ -1,0 +1,3 @@
+216.67.1.91 - leon [01/Jul/2002:12:11:52 +0000] "GET /Stayconnected/RSSFeeds/Drug-Alerts-and-Recalls/index.html HTTP/1.1" 301 431"http://www.mhra.gov.uk/" "Mozilla/4.05 [en] (WinNT; I)" "USERID=CustomerA;IMPID=01234"
+216.67.1.91 - leon [01/Jul/2002:12:11:52 +0000] "GET /Stayconnected/RSSFeeds/Drug-Alerts-and-Recalls/index.html HTTP/1.1" 301 431"http://www.mhra.gov.uk/" "Mozilla/4.05 [en] (WinNT; I)" "USERID=CustomerA;IMPID=01234"
+216.67.1.91 - leon [01/Jul/2002:12:11:52 +0000] "GET /Stayconnected/RSSFeeds/Drug-Alerts-and-Recalls/index.html HTTP/1.1" 301 431"http://www.mhra.gov.uk/" "Mozilla/4.05 [en] (WinNT; I)" "USERID=CustomerA;IMPID=01234"

--- a/spec/fixtures/hits/unknown_log_format.log
+++ b/spec/fixtures/hits/unknown_log_format.log
@@ -1,0 +1,1 @@
+foo, bar, baz

--- a/spec/lib/transition/import/hits_spec.rb
+++ b/spec/lib/transition/import/hits_spec.rb
@@ -242,8 +242,21 @@ describe Transition::Import::Hits do
         expect(Hit.count).to eql(0)
       end
     end
-  end
 
+    context 'when the file is unexpected' do
+      it 'does not create a hit record' do
+        Transition::Import::Hits.from_iis_w3c!('spec/fixtures/hits/unexpected_log_format.log')
+        expect(Hit.count).to eql(0)
+      end
+    end
+
+    context 'when the file is not parseable' do
+      it 'does not create a hit record' do
+        Transition::Import::Hits.from_iis_w3c!('spec/fixtures/hits/unknown_log_format.log')
+        expect(Hit.count).to eql(0)
+      end
+    end
+  end
 
   describe '.from_s3!' do
     let(:bucket) { 'bucket' }


### PR DESCRIPTION
* The application is not in direct control of the contents of the bucket. Somethings files that look like logs, enough to fool the parser are allowed through but fail loudly when they miss fields.
* Even when nil guards are in place, trying to ingest logs where any of the required records is blank causes further failure. We no longer include these lines in the output of the parser.