### PR TITLE
Sidekiq Cron initialised with environment variables

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -31,4 +31,4 @@ Sidekiq::Cron::Job.load_from_hash(
       'args'  => ENV["LOG_BUCKET_NAME"]
     }
   }
-)
+) if ENV['REDIS_URL'].present?

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -22,3 +22,13 @@ Sidekiq.configure_client do |config|
 end
 
 Sidekiq::Logging.logger.level = Logger::WARN if Rails.env.production?
+
+Sidekiq::Cron::Job.load_from_hash(
+  {
+    'daily_ingest_of_ukri_clf_logs' => {
+      'class' => 'IngestW3cLogWorker',
+      'cron'  => '0 8 * * *',
+      'args'  => ENV["LOG_BUCKET_NAME"]
+    }
+  }
+)

--- a/config/schedule.yml
+++ b/config/schedule.yml
@@ -1,5 +1,0 @@
-daily_ingest_of_ukri_clf_logs:
-  cron: "0 8 * * *"
-  class: "IngestW3cLogWorker"
-  args: ukri-transition-hippers-test
-  description: Ingest UKRI log hits every day at 8AM. UKRI are uploading log files to this bucket in combined log format. This task ingests them into hit records.


### PR DESCRIPTION
* Using the schedule.yml route described here https://github.com/ondrejbartas/sidekiq-cron#adding-cron-job didn't work since the interpolationwas directly translated into the sidekiq job.
* This allows the ENV Var `LOG_BUCKET_NAME` to be used to change the bucket name as the source of the log files.