### PR TITLE
fix: ignore comment lines in IIS logs

### DIFF
--- a/lib/transition/import/iis_access_log_parser.rb
+++ b/lib/transition/import/iis_access_log_parser.rb
@@ -27,7 +27,7 @@ module Transition
 
           mapping = {}
           x = nil
-          line.split(/^([^ ]* [^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*)($| )(.*)/).each_with_index do |value, i|
+          line.split(/^(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*)($| )(.*)/).each_with_index do |value, i|
             mapping[IISAccessLogParser.fields[i - 1]] = value unless i.zero?
             x = value if i.zero?
           end

--- a/spec/fixtures/hits/iis_w3c_example.log
+++ b/spec/fixtures/hits/iis_w3c_example.log
@@ -1,3 +1,7 @@
+#Software: Microsoft Internet Information Services 7.5
+#Version: 1.0
+#Date: 2019-09-18 00:00:17
+#Fields: date time s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(User-Agent) cs(Referer) cs-host sc-status sc-substatus sc-win32-status time-taken
 2019-09-17 15:11:25 149.155.50.65 GET /news/ - 80 - 192.171.180.236 Mozilla/5.0+(Windows+NT+6.1;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/76.0.3809.132+Safari/537.36 http://dev.infohub.ukri.org/our-ukri/ dev.infohub.ukri.org 200 0 0 368
 2019-09-17 15:11:27 149.155.50.65 GET /news/ - 80 - 192.171.180.236 Mozilla/5.0+(Windows+NT+6.1;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/76.0.3809.132+Safari/537.36 http://dev.infohub.ukri.org/our-ukri/ dev.infohub.ukri.org 200 0 0 368
 2019-09-17 15:11:29 149.155.50.65 GET /news/ - 80 - 192.171.180.236 Mozilla/5.0+(Windows+NT+6.1;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/76.0.3809.132+Safari/537.36 http://dev.infohub.ukri.org/our-ukri/ dev.infohub.ukri.org 200 0 0 368


### PR DESCRIPTION
By only matching lines that start with valid date/times