### PR TITLE
Fix pull robot

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,6 @@
+---
+version: "1"
+rules:
+  - base: develop
+    upstream: alphagov:master
+    mergeMethod: merge


### PR DESCRIPTION
Robot was configured in #8 but this branch was deprecated and replaced with the current develop branch. This updates the config to also pull from upstream into develop instead of master.