### PR TITLE
Fix Auth0 login

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -4,11 +4,6 @@ class AuthenticationController < ApplicationController
 
   def index; end
 
-  def new
-    logger.info('OAuth Initiating to Auth0')
-    redirect_to '/auth/auth0'
-  end
-
   def create
     logger.info('OAuth Response Received')
     data = request.env['omniauth.auth']

--- a/app/views/authentication/index.html.erb
+++ b/app/views/authentication/index.html.erb
@@ -1,2 +1,2 @@
 <h1>Transition</h1>
-<%= link_to 'Please Login', login_path %>
+<%= link_to 'Please Login', '/auth/auth0/', method: :post %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,6 @@ Rails.application.routes.draw do
   match '/422' => 'errors#error_422', via: %i[get post]
   match '/500' => 'errors#error_500', via: %i[get post]
 
-  get 'login', to: 'authentication#new'
   get 'auth/auth0/callback', to: 'authentication#create'
   get '/auth/gds/sign_out', to: 'authentication#destroy'
 

--- a/spec/routing/routing_spec.rb
+++ b/spec/routing/routing_spec.rb
@@ -6,10 +6,4 @@ describe 'Routing', type: :routing do
       expect(get: '/').to route_to('authentication#index')
     end
   end
-
-  describe 'login' do
-    it "should route '/login', :to => 'authentication#new'" do
-      expect(get: '/login').to route_to('authentication#new')
-    end
-  end
 end


### PR DESCRIPTION
In c642ee50 we changed from using Zendesk (via Omniauth) as our auth
provider to using Auth0 (again, via Omniauth). James S tells me that he
was unable to test his changes locally at the time so we never confirmed
that the new login was actually working. I just tried using it now.

After clicking the 'Please Login' button, we redirected to GET
/auth/auth0, which gave a 404.

The Auth0 Rails Quickstart guide [1] suggests that this request needs to
be a POST:

> To prevent forged authentication requests, make sure that you add a link
> with a method of :post (as described below using the link_to function in
> Rails) or create a form with a CSRF token included.

I don't know if / why this was working with a GET when we used Zendesk
as the Auth0 provider, and I haven't investigated it.

I've changed it so that the 'Please Login' button makes a POST request
to /auth/auth0 directly. This removes the need for
AuthenticationController#new so I've got rid of that.

[1] https://auth0.com/docs/quickstart/webapp/rails#trigger-authentication