### PR TITLE
Update #originator to #paper_trail.originator

### DIFF
--- a/app/views/admin/whitelisted_hosts/index.html.erb
+++ b/app/views/admin/whitelisted_hosts/index.html.erb
@@ -37,7 +37,7 @@
       <tr <% if flash[:hostname] == host.hostname %>class="selected-row"<% end %>>
         <td><%= host.hostname %></td>
         <td><%= I18n.l host.created_at, :format => :govuk_date %></td>
-        <td><%= host.originator %></td>
+        <td><%= host.paper_trail.originator %></td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
originator was changed in paper_trail 9, but never got updated here for some reason. Resolves https://trello.com/c/6Hxx58Kh