### PR TITLE
Check that current user is authenticated before showing the logout link

### DIFF
--- a/features/top_navigation.feature
+++ b/features/top_navigation.feature
@@ -1,5 +1,9 @@
 Feature: Top Navigation
 
+  Scenario: User sees a login prompt on homepage
+    When I visit the home page
+    Then I should see "Please Login"
+
   Scenario: User has an organisation
     Given I have logged in as a member of DCLG
     When I visit the home page

--- a/vendor/gems/govuk_admin_template-6.7.0/app/views/layouts/govuk_admin_template.html.erb
+++ b/vendor/gems/govuk_admin_template-6.7.0/app/views/layouts/govuk_admin_template.html.erb
@@ -74,7 +74,7 @@
                 </ul>
               <% end %>
 
-              <% if GovukAdminTemplate::Config.show_signout %>
+              <% if GovukAdminTemplate::Config.show_signout && current_user.authenticated? %>
                 <div class="navbar-text pull-right">
                   <%= current_user.email %>
                   &bull; <%= link_to 'Sign out', '/auth/gds/sign_out' %>


### PR DESCRIPTION
As the link is now their email address, it explodes if you try to display it with NilUser. So, we'd better check first.