### PR TITLE
Show all organisations in the organisations list, even if they have no sites

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -2,7 +2,7 @@ class OrganisationsController < ApplicationController
   before_action :set_organisation, only: %i[show update edit]
 
   def index
-    @organisations = Organisation.with_sites.order(:title)
+    @organisations = Organisation.order(:title)
     @site_count = Site.count
   end
 

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -24,26 +24,6 @@ class Organisation < ActiveRecord::Base
   validates_presence_of :title
   validates_presence_of :content_id
 
-  # We have two ways of joining a site to an org:
-  # 1. By the site's FK relationship to organisations
-  # 2. Through the many-to-many organisations_sites
-  #
-  # UNION these two ways in an INNER JOIN to pretend that the FK relationship
-  # is in fact a row in organisations_sites.
-  scope :with_sites, -> {
-    select('organisations.*, COUNT(*) as site_count').
-    joins('
-      INNER JOIN (
-        SELECT organisation_id, site_id FROM organisations_sites
-        UNION
-        SELECT s.organisation_id, s.id FROM sites s
-      ) AS organisations_sites ON organisations_sites.organisation_id = organisations.id
-    ').
-    joins('INNER JOIN sites ON sites.id = organisations_sites.site_id').
-    group('organisations.id'). # Postgres will accept a group by primary key
-    having('COUNT(*) > 0')
-  }
-
   # Returns organisations ordered by descending error count across
   # all their sites.
   scope :leaderboard, -> {

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -19,11 +19,11 @@ Feature: List organisations
     When I visit the home page
     Then I should see "@example.com"
     And I should see the header "Organisations"
-    And I should see an organisations table with 3 rows
+    And I should see an organisations table with 4 rows
     And I should see a link to the organisation bis
     And I should see a link to the organisation fco
     And I should see a link to the organisation go-science
-    But I should not see a link to the organisation ukti
+    And I should see a link to the organisation ukti
 
   @javascript
   Scenario: See the "jump to a site or mapping" link with Javascript enabled

--- a/spec/factories/organisations.rb
+++ b/spec/factories/organisations.rb
@@ -8,7 +8,9 @@ FactoryBot.define do
     content_id { SecureRandom.uuid }
 
     trait :with_site do
-      after(:create) { |o| o.sites = FactoryBot.create_list(:site, 1) }
+      after(:create) do |site, _|
+        create_list(:site, 1, organisation: site)
+      end
     end
   end
 end


### PR DESCRIPTION
This reverts some functionality which made sense for the GOV.UK Transition Tool but which is more confusing than beneficial for us. See commit messages for more details.