### PR TITLE
Remove mentions of "Proposition Manager"

### DIFF
--- a/app/controllers/mappings_controller.rb
+++ b/app/controllers/mappings_controller.rb
@@ -110,7 +110,7 @@ class MappingsController < ApplicationController
     unless site
       render_error(404,
                    header: 'Unknown site',
-                   body:  "#{url.host} isn't configured in Transition yet. To add this site to Transition, please contact your Proposition Manager.")
+                   body:  "#{url.host} isn't configured in Transition yet.")
       return
     end
 

--- a/app/views/sites/_global_type.html.erb
+++ b/app/views/sites/_global_type.html.erb
@@ -15,8 +15,7 @@
           For example: <br />
           http://<%= @site.default_host.hostname %><strong>/specific/path</strong> <br />
           gets redirected to: <br />
-          <%= @site.global_new_url %><strong>/specific/path</strong> <br /><br />
-          To make changes please contact your Proposition Manager.
+          <%= @site.global_new_url %><strong>/specific/path</strong>
         <% elsif @site.global_redirect? %>
           <%= I18n.t('mappings.global_type.redirect') %>
         <% elsif @site.global_archive? %>

--- a/app/views/sites/_tools.html.erb
+++ b/app/views/sites/_tools.html.erb
@@ -12,7 +12,7 @@
         </li>
       </ul>
     <% else %>
-      This tool requires <%= link_to 'AKA Domains', glossary_index_path(anchor: 'aka'), class: 'link-inherit' %> to be set up. Please contact your Proposition Manager.
+      This tool requires <%= link_to 'AKA Domains', glossary_index_path(anchor: 'aka'), class: 'link-inherit' %> to be set up.
     <% end %>
     <hr />
     <h4 class="remove-top-margin">Preview redirections</h4>
@@ -27,7 +27,7 @@
       </ul>
       <a class="btn btn-default bookmarklet" title="Drag me to your bookmarks bar" data-toggle="tooltip" href="javascript:location%3Dlocation.href.replace(/:%5C/%5C//, '://aka-').replace(/-*www/,'')">Preview redirect</a>
     <% else %>
-      This tool requires <%= link_to 'AKA Domains', glossary_index_path(anchor: 'aka'), class: 'link-inherit' %> to be set up. Please contact your Proposition Manager.
+      This tool requires <%= link_to 'AKA Domains', glossary_index_path(anchor: 'aka'), class: 'link-inherit' %> to be set up.
     <% end %>
     <hr />
     <h4 class="add-top-margin">National Archives checker</h4>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,5 +37,5 @@ en:
         mappings_empty: 'No mappings were selected'
         tag_list_empty: "No tags were given"
     global_type:
-      redirect: 'This is known as a global redirect. The entire old site redirects to a single page. To make changes please contact your Proposition Manager.'
-      archive: "This is known as a global archive. The entire old site has been archived because it doesn't meet a user need. To make changes please contact your organisation's Proposition Manager."
+      redirect: 'This is known as a global redirect. The entire old site redirects to a single page.'
+      archive: "This is known as a global archive. The entire old site has been archived because it doesn't meet a user need."


### PR DESCRIPTION
Proposition Manager is a role that existed in GDS whilst the GOV.UK site
was being developed. I don’t know if it exists any more, but it
certainly doesn’t exist in dxw.

I am not sure whether the actions that required a Proposition Manager
are relevant to our uses of the Transition Tool. I also don’t know how
the Proposition Manager would have performed these actions. So I haven’t
added any guidance about how a user of the tool can now perform these
actions.