### PR TITLE
Make organisations#show and sites#show handle a site with no hosts

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,4 +27,8 @@ module ApplicationHelper
       org.title
     end
   end
+
+  def site_display_name(site)
+    site.default_host&.hostname || "#{site.abbr} (no hosts configured)"
+  end
 end

--- a/app/views/organisations/show.html.erb
+++ b/app/views/organisations/show.html.erb
@@ -34,7 +34,7 @@
     <% @sites.each do |site| %>
       <tr>
         <td>
-          <%= link_to site.default_host.hostname, site_path(site), class: 'breakable js-open-on-submit' %>
+          <%= link_to site_display_name(site), site_path(site), class: 'breakable js-open-on-submit' %>
           <% if site.organisation != @organisation %>
             <br><span class="text-muted">owned by</span>
             <%= link_to site.organisation.title, site.organisation, class: 'link-muted' %>

--- a/app/views/sites/_performance.html.erb
+++ b/app/views/sites/_performance.html.erb
@@ -7,7 +7,7 @@
         Graphs and tables charting
         <abbr title="Resources served from the website including pages, images and file downloads."
               data-toggle="tooltip">hits</abbr>
-        to <%= @site.default_host.hostname %>. Use analytics to see how many users
+        to <%= site_display_name(@site) %>. Use analytics to see how many users
         are visiting old URLs and what proportion of them are being
         redirected, seeing archives or finding errors.
       </p>

--- a/app/views/sites/_tools.html.erb
+++ b/app/views/sites/_tools.html.erb
@@ -2,7 +2,7 @@
   <h3 class="panel-heading remove-top-margin">Tools</h3>
   <div class="panel-body">
     <h4 class="remove-top-margin">Side by side browser</h4>
-    <% if site.default_host.aka_host && site.default_host.aka_host.redirected_by_gds? %>
+    <% if site.default_host&.aka_host&.redirected_by_gds? %>
       <p>
         Browse <i><%= site.default_host.hostname %></i> in the left panel, and, as you navigate, preview redirections and archives in the right panel.
       </p>
@@ -16,7 +16,7 @@
     <% end %>
     <hr />
     <h4 class="remove-top-margin">Preview redirections</h4>
-    <% if site.default_host.aka_host && site.default_host.aka_host.redirected_by_gds? %>
+    <% if site.default_host&.aka_host&.redirected_by_gds? %>
       <p>
         To test a redirection for a pre-transition website:
       </p>

--- a/app/views/sites/show.html.erb
+++ b/app/views/sites/show.html.erb
@@ -1,9 +1,9 @@
-<% content_for(:page_title, @site.default_host.hostname) %>
+<% content_for(:page_title, site_display_name(@site)) %>
 
 <% breadcrumb :site, @site %>
 
 <div class="page-title-with-border">
-  <h1><%= @site.default_host.hostname %></h1>
+  <h1><%= site_display_name(@site) %></h1>
 </div>
 
 <div class="row">

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -8,7 +8,7 @@ crumb :organisation do |organisation|
 end
 
 crumb :site do |site|
-  link site.default_host.hostname, site_path(site)
+  link site_display_name(site), site_path(site)
   parent :organisation, site.organisation
 end
 

--- a/spec/controllers/organisation_controller_spec.rb
+++ b/spec/controllers/organisation_controller_spec.rb
@@ -21,6 +21,16 @@ describe OrganisationsController do
       get :show, params: { id: organisation.whitehall_slug }
       expect(assigns(:organisation)).to eq(organisation)
     end
+
+    context 'when an organisation has a site without hosts' do
+      render_views
+      let(:organisation) { create :organisation, sites: create_list(:site_without_host, 1) }
+
+      it 'renders a sensible placeholder name for the site' do
+        get :show, params: { id: organisation.whitehall_slug }
+        expect(response.body).to include("#{organisation.sites.first.abbr} (no hosts configured)")
+      end
+    end
   end
 
   describe '#new' do

--- a/spec/controllers/sites_controller_spec.rb
+++ b/spec/controllers/sites_controller_spec.rb
@@ -36,6 +36,16 @@ describe SitesController do
         get :show, params: { id: site.abbr }
         expect(assigns(:site)).to eq(site)
       end
+
+      context 'when the site has no hosts' do
+        render_views
+
+        it 'renders a sensible placeholder name for the site' do
+          site = create :site_without_host
+          get :show, params: { id: site.abbr }
+          expect(response.body).to include("#{site.abbr} (no hosts configured)")
+        end
+      end
     end
 
     describe '#new' do


### PR DESCRIPTION
We have been seeing Rollbar errors about this -
https://rollbar.com/dxw/ukri-transition/items/8/. It's possible to
create a site with no hosts, so the app should handle it.