### PR TITLE
(Fix) Run ingestion process at 8

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -27,7 +27,7 @@ Sidekiq::Cron::Job.load_from_hash(
   {
     'daily_ingest_of_ukri_clf_logs' => {
       'class' => 'IngestW3cLogWorker',
-      'cron'  => '0 * * * *',
+      'cron'  => '0 8 * * *',
       'args'  => ENV["LOG_BUCKET_NAME"]
     }
   }


### PR DESCRIPTION
Running this job hourly is causing the site to run slow (consuming most
of the available memory while it's running)