### PR TITLE
Fix test where date had gone out of range of selector

### DIFF
--- a/features/site.feature
+++ b/features/site.feature
@@ -121,7 +121,7 @@ Scenario: Editing a site's transition date as a GDS Editor
   When I edit this site's transition date
   Then I should be redirected to the site dashboard
   And I should see "Site updated successfully"
-  And I should see "20 September 2014"
+  And I should see the new transition date
 
 Scenario: Editing a site's transition date as a non-GDS Editor
   Given I have logged in as a member of DCLG

--- a/features/step_definitions/site_interaction_steps.rb
+++ b/features/step_definitions/site_interaction_steps.rb
@@ -4,8 +4,13 @@ end
 
 When(/^I edit this site's transition date$/) do
   click_link 'Edit date'
-  select('2014', from: 'site_launch_date_1i')
-  select('September', from: 'site_launch_date_2i')
-  select('20', from: 'site_launch_date_3i')
+  @transition_date = 1.month.from_now
+  select(@transition_date.year, from: 'site_launch_date_1i')
+  select(I18n.t("date.month_names")[@transition_date.month], from: 'site_launch_date_2i')
+  select(@transition_date.day, from: 'site_launch_date_3i')
   click_button 'Save'
+end
+
+Then(/^I should see the new transition date$/) do
+  expect(page).to have_content(@transition_date.strftime("%-d %B %Y"))
 end


### PR DESCRIPTION
The Rails date_select shows years from 5 years ago by default - this test used 2014, which is now too far back. Changed to test based on on today's date. FIxes the test failure seen in #67 