### PR TITLE
Optimise ingestion of IIS logs from S3

### DIFF
--- a/app/workers/ingest_w3c_log_worker.rb
+++ b/app/workers/ingest_w3c_log_worker.rb
@@ -17,6 +17,9 @@ class IngestW3cLogWorker
         if import_record.content_hash == object.etag
           puts "Already ingested #{object.key} - skipping" unless Rails.env.test?
           next
+        else
+          import_record.content_hash = object.etag
+          import_record.save!
         end
 
         begin

--- a/lib/tasks/import/hits.rake
+++ b/lib/tasks/import/hits.rake
@@ -40,6 +40,6 @@ namespace :import do
   desc 'Import hits from S3 files in a W3C log format'
   task :from_w3c_files, [:bucket] => :environment do |_, args|
     bucket = args[:bucket]
-    IngestW3cLogs.perform_async(bucket)
+    IngestW3cLogWorker.new.perform(bucket)
   end
 end

--- a/spec/workers/ingest_w3c_log_worker_spec.rb
+++ b/spec/workers/ingest_w3c_log_worker_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'rails_helper'
 
 describe IngestW3cLogWorker, type: :worker do
   let(:s3) { Aws::S3::Client.new(stub_responses: true) }

--- a/spec/workers/ingest_w3c_log_worker_spec.rb
+++ b/spec/workers/ingest_w3c_log_worker_spec.rb
@@ -8,65 +8,43 @@ describe IngestW3cLogWorker, type: :worker do
   end
 
   describe 'perform' do
-    before(:each) do
-      key = 'results.csv'
-      file = 'iis_w3c_example.log'
+    let(:bucket) {"bucket-name"}
+    let(:key) {"results.csv"}
+    let(:file) {"iis_w3c_example.log"}
 
+    before(:each) do
       s3.stub_responses(:list_objects, contents: [{ key: key, etag: file }])
       s3.stub_responses(:get_object, body: File.open("spec/fixtures/hits/#{file}"))
     end
 
     it 'fetches files from S3' do
       Sidekiq::Testing.inline! do
-        bucket = 'bucket-name'
-        key = 'results.csv'
-        file = 'iis_w3c_example.log'
-
-        s3.stub_responses(:list_objects, contents: [{ key: key, etag: file }])
-        s3.stub_responses(:get_object, body: File.open("spec/fixtures/hits/#{file}"))
-
         expect(s3).to receive(:list_objects).with(bucket: bucket).and_call_original
         expect(s3).to receive(:get_object).with(bucket: bucket, key: key, response_target: /ingest/).and_call_original
-
         subject.perform(bucket)
       end
     end
 
     it 'asks the import service to ingest the file' do
-      bucket = 'bucket-name'
-
       expect(Transition::Import::Hits).to receive(:from_iis_w3c!)
-
       subject.perform(bucket)
     end
 
     it 'uses the ingest queue' do
-      described_class.perform_async('bucket-name')
+      described_class.perform_async(bucket)
       expect(Sidekiq::Queues['ingest'].size).to eq(1)
     end
 
     it 'refreshes the analytics' do
-      bucket = 'bucket-name'
-
       expect(Transition::Import::DailyHitTotals).to receive(:from_hits!)
       expect(Transition::Import::HitsMappingsRelations).to receive(:refresh!)
-
       subject.perform(bucket)
     end
 
     context 'when that file has already been ingested' do
       it 'does not ingest those logs again' do
-        bucket = 'bucket-name'
-        key = 'results.csv'
-        file = 'iis_w3c_example.log'
-
-        s3.stub_responses(:list_objects, contents: [{ key: key, etag: file }])
-        s3.stub_responses(:get_object, body: File.open("spec/fixtures/hits/#{file}"))
-
         ImportedHitsFile.where(filename: file)
-
         subject.perform(bucket)
-
         expect(ImportedHitsFile.count).to eq(1)
       end
     end


### PR DESCRIPTION
The ingestion process should have been tracking which files were already imported and not doing them twice, but it wasn't working. That's because the content hash for the `ImportedHitsFile` (and the object itself, in fact) wasn't being saved. This should fix it.