### PR TITLE
Allow editing of site hosts

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -20,6 +20,7 @@ class SitesController < ApplicationController
 
   def update
     if @site.update(site_params)
+      create_host
       redirect_to site_path(@site), flash: { success: 'Site updated successfully' }
     else
       render :edit, flash: { alert: "We couldn't save your change" }
@@ -38,7 +39,7 @@ class SitesController < ApplicationController
 
     host_list = hosts.split(',')
     host_list.each do |host|
-      Host.create(hostname: host, cname: host, site: @site).save
+      Host.find_or_create_by(hostname: host.strip, cname: host, site: @site)
     end
   end
 

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -39,7 +39,9 @@ class SitesController < ApplicationController
 
     host_list = hosts.split(',')
     host_list.each do |host|
-      Host.find_or_create_by(hostname: host.strip, cname: host, site: @site)
+      Host.find_or_create_by(hostname: host.strip, site: @site) do |h|
+        h.cname = host.strip
+      end
     end
   end
 

--- a/app/views/sites/edit.html.erb
+++ b/app/views/sites/edit.html.erb
@@ -1,10 +1,10 @@
-<% content_for(:page_title, @site.default_host.hostname) %>
+<% content_for(:page_title, @site&.default_host&.hostname) %>
 
 <% breadcrumb :edit_site, @site %>
 
 <div class="page-title-with-border">
   <h1>
-    <small><%= @site.default_host.hostname %></small>
+    <small><%= @site&.default_host&.hostname %></small>
     <br />
     Edit transition date
   </h1>


### PR DESCRIPTION
Before hosts were only created on SitesController#create. This adds it to #update as well, and makes sure that duplicates are not created.