### PR TITLE
Address some rspec deprecations

### DIFF
--- a/spec/lib/transition/import/iis_access_log_parser_spec.rb
+++ b/spec/lib/transition/import/iis_access_log_parser_spec.rb
@@ -10,42 +10,42 @@ describe Transition::Import::IISAccessLogParser::Entry do
 
     described_class.from_string("2011-06-20 00:00:00 38.111.242.43 GET /SharedControls/getListingThumbs.aspx img=48,13045,27801,25692,35,21568,21477,21477,10,18,46,8&premium=0|1|0|0|0|0|0|0|0|0|0|0&h=100&w=125&pos=175&scale=true 80 - 92.20.10.104 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+6.1;+Trident/4.0;+GTB6.6;+SLCC2;+.NET+CLR+2.0.50727;+.NET+CLR+3.5.30729;+.NET+CLR+3.0.30729;+Media+Center+PC+6.0;+aff-kingsoft-ciba;+.NET4.0C;+MASN;+AskTbSTC/5.8.0.12304) - 200 0 0 609 test oter now")
 
-    # lambda{ IISAccessLogParser::Entry.from_string("2011-06-20 00:00:00 38.111.242.43 GET /SharedControls/getListingThumbs.aspx img=48,13045,27801,25692,35,21568,21477,21477,10,18,46,8&premium=0|1|0|0|0|0|0|0|0|0|0|0&h=100&w=125&pos=175&scale=true 80 - 92.20.10.104 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+6.1;+Trident/4.0;+GTB6.6;+SLCC2;+.NET+CLR+2.0.50727;+.NET+CLR+3.5.30729;+.NET+CLR+3.0.30729;+Media+Center+PC+6.0;+aff-kingsoft-ciba;+.NET4.0C;+MASN;+AskTbSTC/5.") }.should raise_error ArgumentError
+    # lambda{ IISAccessLogParser::Entry.from_string("2011-06-20 00:00:00 38.111.242.43 GET /SharedControls/getListingThumbs.aspx img=48,13045,27801,25692,35,21568,21477,21477,10,18,46,8&premium=0|1|0|0|0|0|0|0|0|0|0|0&h=100&w=125&pos=175&scale=true 80 - 92.20.10.104 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+6.1;+Trident/4.0;+GTB6.6;+SLCC2;+.NET+CLR+2.0.50727;+.NET+CLR+3.5.30729;+.NET+CLR+3.0.30729;+Media+Center+PC+6.0;+aff-kingsoft-ciba;+.NET4.0C;+MASN;+AskTbSTC/5.") }).to raise_error ArgumentError
   end
 
   it "should contain properly parsed date types" do
     e = described_class.from_string("2019-12-17 15:11:25 149.155.50.65 GET /news/ - 80 - 192.171.180.236 Mozilla/5.0+(Windows+NT+6.1;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/76.0.3809.132+Safari/537.36 http://dev.infohub.ukri.org/our-ukri/ dev.infohub.ukri.org 200 0 0 368")
 
-    e.date.should be_kind_of Time
-    e.date.day.should eql 17
-    e.date.month.should eql 12
-    e.date.year.should eql 2019
-    e.date.hour.should eql 15
-    e.date.min.should eql 11
-    e.date.sec.should eql 25
-    e.date.zone.should eql "UTC"
+    expect(e.date.day).to eql 17
+    expect(e.date.month).to eql 12
+    expect(e.date).to be_kind_of Time
+    expect(e.date.year).to eql 2019
+    expect(e.date.hour).to eql 15
+    expect(e.date.min).to eql 11
+    expect(e.date.sec).to eql 25
+    expect(e.date.zone).to eql "UTC"
 
-    e.server_ip.should be_kind_of IP::V4
-    e.client_ip.should be_kind_of IP::V4
+    expect(e.server_ip).to be_kind_of IP::V4
+    expect(e.client_ip).to be_kind_of IP::V4
 
-    e.port.should be_kind_of Integer
-    e.status.should be_kind_of Integer
-    e.substatus.should be_kind_of Integer
-    e.win32_status.should be_kind_of Integer
+    expect(e.port).to be_kind_of Integer
+    expect(e.status).to be_kind_of Integer
+    expect(e.substatus).to be_kind_of Integer
+    expect(e.win32_status).to be_kind_of Integer
 
-    e.time_taken.should be_kind_of Float
-    e.time_taken.should eql 0.368
+    expect(e.time_taken).to be_kind_of Float
+    expect(e.time_taken).to eql 0.368
 
-    e.username.should be_nil
+    expect(e.username).to be_nil
 
-    e.user_agent.should eql "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36"
-    e.user_referer.should eql "http://dev.infohub.ukri.org/our-ukri/"
+    expect(e.user_agent).to eql "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36"
+    expect(e.user_referer).to eql "http://dev.infohub.ukri.org/our-ukri/"
   end
 
   it "should handle correctly nil useragent" do
     e = described_class.from_string("2011-06-20 00:01:02 38.111.242.43 GET /SharedControls/getListingThumbs.aspx img=48,13045,27801,25692,35,21568,21477,21477,10,18,46,8&premium=0|1|0|0|0|0|0|0|0|0|0|0&h=100&w=125&pos=175&scale=true 80 - 92.20.10.104 - 200 0 0 609 test oter now")
 
-    e.user_agent.should be_nil
+    expect(e.user_agent).to be_nil
   end
 
   it "should handle strings containing invalid UTF-8 bytes" do
@@ -54,7 +54,7 @@ describe Transition::Import::IISAccessLogParser::Entry do
     e = described_class.from_string(invalid_line)
     # It's replaced during parsing with `\uFFFD`, the standard replacement
     # character: https://www.fileformat.info/info/unicode/char/fffd/index.htm
-    e.url.should == "/news?q=char\uFFFD"
+    expect(e.url).to eq "/news?q=char\uFFFD"
   end
 end
 
@@ -67,7 +67,7 @@ describe Transition::Import::IISAccessLogParser do
       end
     end
 
-    last.url.should == "/news/"
+    expect(last.url).to eq "/news/"
   end
 
   it "should allow reading entries from file" do
@@ -76,6 +76,6 @@ describe Transition::Import::IISAccessLogParser do
       last = entry
     end
 
-    last.url.should == "/news/"
+    expect(last.url).to eq "/news/"
   end
 end


### PR DESCRIPTION
The `should` syntax is deprecated, it has been replaced with `expect`

Additionally, some `around` blocks were incorrect, `around(:all)` was including
contexts, which are not affected by `around` instructions. Changing this to
`around(:example)` has the desired effect without raising a warning.