### PR TITLE
Fix the display of user info in the navigation bar

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,12 @@
     <%= link_to 'Glossary', glossary_index_path %>
   </li>
 <% end %>
+<% content_for :navbar_right do %>
+  <%- if current_user.respond_to?(:email) %>
+    <%= current_user.email %>
+    &bull; <%= link_to 'Sign out', '/auth/gds/sign_out' %>
+  <%- end %>
+<% end %>
 
 <% content_for :favicon do %>
   <% environment_style = GovukAdminTemplate.environment_style %>

--- a/config/initializers/govuk_admin_template.rb
+++ b/config/initializers/govuk_admin_template.rb
@@ -1,4 +1,4 @@
 GovukAdminTemplate.configure do |c|
   c.app_title = "dxw Transition Tool"
-  c.show_signout = true
+  c.show_signout = false
 end

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -17,7 +17,7 @@ Feature: List organisations
 
   Scenario: Visit the list page
     When I visit the home page
-    Then I should see "@example.com"
+    Then I should see my email
     And I should see the header "Organisations"
     And I should see an organisations table with 4 rows
     And I should see a link to the organisation bis

--- a/features/organisations.feature
+++ b/features/organisations.feature
@@ -17,7 +17,7 @@ Feature: List organisations
 
   Scenario: Visit the list page
     When I visit the home page
-    Then I should see "Stub User"
+    Then I should see "@example.com"
     And I should see the header "Organisations"
     And I should see an organisations table with 4 rows
     And I should see a link to the organisation bis

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -1,8 +1,8 @@
 include Warden::Test::Helpers
 
 Given(/^I have logged in as a GDS Editor$/) do
-  user = create(:gds_editor)
-  login_as(user)
+  @user = create(:gds_editor)
+  login_as(@user)
 end
 
 Given(/^I have logged in as an admin$/) do
@@ -35,4 +35,8 @@ end
 Given(/^I have logged in as a member of another organisation$/) do
   user = create(:user, organisation_content_id: SecureRandom.uuid)
   login_as(user)
+end
+
+Given(/^I should see my email$/) do
+  expect(page).to have_content(@user.email)
 end


### PR DESCRIPTION
After the upstream merge of alhpagov/transition:master the navigation bar
was not showing the correct information - it was showing the user's auth0
identifier which was linked to a gov.uk website (signon.dev.gov.uk)

This commit fixes the navigation to show the user's email (which is what was
shown before the upstream merge) and no longer links to a gov.uk site.

Before:
<img width="1076" alt="Screenshot 2020-10-26 at 14 25 44" src="https://user-images.githubusercontent.com/1089521/97186747-91e3e980-1799-11eb-8340-6f5ae95f9b14.png">

After:
<img width="1083" alt="Screenshot 2020-10-26 at 14 26 48" src="https://user-images.githubusercontent.com/1089521/97186757-95777080-1799-11eb-83bb-411c4c3cf568.png">
