### PR TITLE
Remove the Gov.uk crown logo

### DIFF
--- a/app/assets/stylesheets/nav.scss
+++ b/app/assets/stylesheets/nav.scss
@@ -1,3 +1,9 @@
+.navbar .container .navbar-brand,
+.navbar .container-fluid .navbar-brand {
+  background: none;
+  padding-left: 0;
+}
+
 /* ==========================================================================
    Nav compact
    ========================================================================== */


### PR DESCRIPTION
This was mistakenly re-added during a recent upstream merge

Before:
<img width="1083" alt="Screenshot 2020-10-26 at 14 26 48" src="https://user-images.githubusercontent.com/1089521/97990690-3dafb980-1dd8-11eb-8a37-fcf15b0647a8.png">

After:
<img width="1096" alt="Screenshot 2020-11-03 at 13 25 28" src="https://user-images.githubusercontent.com/1089521/97990718-44d6c780-1dd8-11eb-9a50-1652fd43eb16.png">
