### PR TITLE
Refactor IISAccessLogParser and tests

### DIFF
--- a/lib/transition/import/iis_access_log_parser.rb
+++ b/lib/transition/import/iis_access_log_parser.rb
@@ -16,18 +16,33 @@ module Transition
         @fields = fields
       end
 
-      # Fields: date time s-ip cs-method cs-uri-stem cs-uri-query s-port cs-username c-ip cs(User-Agent) cs(Referer) cs-host sc-status sc-substatus sc-win32-status time-taken
-      # Entry = Entry.new
-
       class Entry < OpenStruct
+        IIS_LOG_FIELDS = {
+          date: "(\\d{4}-\\d{2}-\\d{2}[ T]\\d{2}:\\d{2}:\\d{2})",
+          server_ip: "([^ ]*)",
+          method: "([^ ]*)",
+          url: "([^ ]*)",
+          query: "([^ ]*)",
+          port: "([^ ]*)",
+          username: "([^ ]*)",
+          client_ip: "([^ ]*)",
+          user_agent: "([^ ]*)",
+          user_referer: "([^ ]*)",
+          host: "([^ ]*)",
+          status: "([^ ]*)",
+          substatus: "([^ ]*)",
+          win32_status: "([^ ]*)",
+          time_taken: "([^ ]*)",
+        }.freeze
+
+        def self.line_regex
+          Regexp.new("^" + IIS_LOG_FIELDS.values.join("\\s"))
+        end
+
         def self.from_string(line)
-          # 2011-06-20 00:00:00 83.222.242.43 GET /SharedControls/getListingThumbs.aspx img=48,13045,27801,25692,35,21568,21477,21477,10,18,46,8&premium=0|1|0|0|0|0|0|0|0|0|0|0&h=100&w=125&pos=175&scale=true 80 - 92.20.10.104 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+6.1;+Trident/4.0;+GTB6.6;+SLCC2;+.NET+CLR+2.0.50727;+.NET+CLR+3.5.30729;+.NET+CLR+3.0.30729;+Media+Center+PC+6.0;+aff-kingsoft-ciba;+.NET4.0C;+MASN;+AskTbSTC/5.8.0.12304) - 200 0 0 609
-
-          #      x, date, server_ip, method, url, query, port, username, client_ip, user_agent, user_referer status, substatus, win32_status, time_taken, y, other = *line.match(/^([^ ]* [^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*)($| )(.*)/)
-
           mapping = {}
           x = nil
-          line.scrub.split(/^(\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*)($| )(.*)/).each_with_index do |value, i|
+          line.scrub.split(line_regex).each_with_index do |value, i|
             mapping[IISAccessLogParser.fields[i - 1]] = value unless i.zero?
             x = value if i.zero?
           end

--- a/spec/lib/transition/import/iis_access_log_parser_spec.rb
+++ b/spec/lib/transition/import/iis_access_log_parser_spec.rb
@@ -6,55 +6,56 @@ require "rails_helper"
 
 describe Transition::Import::IISAccessLogParser::Entry do
   it "can be constructed from string" do
-    described_class.from_string("2011-06-20 00:00:00 38.111.242.43 GET /SharedControls/getListingThumbs.aspx img=48,13045,27801,25692,35,21568,21477,21477,10,18,46,8&premium=0|1|0|0|0|0|0|0|0|0|0|0&h=100&w=125&pos=175&scale=true 80 - 92.20.10.104 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+6.1;+Trident/4.0;+GTB6.6;+SLCC2;+.NET+CLR+2.0.50727;+.NET+CLR+3.5.30729;+.NET+CLR+3.0.30729;+Media+Center+PC+6.0;+aff-kingsoft-ciba;+.NET4.0C;+MASN;+AskTbSTC/5.8.0.12304) - 200 0 0 609")
+    line = "2011-06-20 00:00:00 38.111.242.43 GET /SharedControls/getListingThumbs.aspx img=48,13045,27801,25692,35,21568,21477,21477,10,18,46,8&premium=0|1|0|0|0|0|0|0|0|0|0|0&h=100&w=125&pos=175&scale=true 80 - 92.20.10.104 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+6.1;+Trident/4.0;+GTB6.6;+SLCC2;+.NET+CLR+2.0.50727;+.NET+CLR+3.5.30729;+.NET+CLR+3.0.30729;+Media+Center+PC+6.0;+aff-kingsoft-ciba;+.NET4.0C;+MASN;+AskTbSTC/5.8.0.12304) - 200 0 0 609"
+    line_with_extras = "2011-06-20 00:00:00 38.111.242.43 GET /SharedControls/getListingThumbs.aspx img=48,13045,27801,25692,35,21568,21477,21477,10,18,46,8&premium=0|1|0|0|0|0|0|0|0|0|0|0&h=100&w=125&pos=175&scale=true 80 - 92.20.10.104 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+6.1;+Trident/4.0;+GTB6.6;+SLCC2;+.NET+CLR+2.0.50727;+.NET+CLR+3.5.30729;+.NET+CLR+3.0.30729;+Media+Center+PC+6.0;+aff-kingsoft-ciba;+.NET4.0C;+MASN;+AskTbSTC/5.8.0.12304) - 200 0 0 609 test other none"
 
-    described_class.from_string("2011-06-20 00:00:00 38.111.242.43 GET /SharedControls/getListingThumbs.aspx img=48,13045,27801,25692,35,21568,21477,21477,10,18,46,8&premium=0|1|0|0|0|0|0|0|0|0|0|0&h=100&w=125&pos=175&scale=true 80 - 92.20.10.104 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+6.1;+Trident/4.0;+GTB6.6;+SLCC2;+.NET+CLR+2.0.50727;+.NET+CLR+3.5.30729;+.NET+CLR+3.0.30729;+Media+Center+PC+6.0;+aff-kingsoft-ciba;+.NET4.0C;+MASN;+AskTbSTC/5.8.0.12304) - 200 0 0 609 test oter now")
-
-    # lambda{ IISAccessLogParser::Entry.from_string("2011-06-20 00:00:00 38.111.242.43 GET /SharedControls/getListingThumbs.aspx img=48,13045,27801,25692,35,21568,21477,21477,10,18,46,8&premium=0|1|0|0|0|0|0|0|0|0|0|0&h=100&w=125&pos=175&scale=true 80 - 92.20.10.104 Mozilla/4.0+(compatible;+MSIE+8.0;+Windows+NT+6.1;+Trident/4.0;+GTB6.6;+SLCC2;+.NET+CLR+2.0.50727;+.NET+CLR+3.5.30729;+.NET+CLR+3.0.30729;+Media+Center+PC+6.0;+aff-kingsoft-ciba;+.NET4.0C;+MASN;+AskTbSTC/5.") }).to raise_error ArgumentError
+    expect(described_class.from_string(line)).to be_a(Transition::Import::IISAccessLogParser::Entry)
+    expect(described_class.from_string(line_with_extras)).to be_a(Transition::Import::IISAccessLogParser::Entry)
   end
 
-  it "should contain properly parsed date types" do
-    e = described_class.from_string("2019-12-17 15:11:25 149.155.50.65 GET /news/ - 80 - 192.171.180.236 Mozilla/5.0+(Windows+NT+6.1;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/76.0.3809.132+Safari/537.36 http://dev.infohub.ukri.org/our-ukri/ dev.infohub.ukri.org 200 0 0 368")
+  it "should contain properly parsed types" do
+    line = "2019-12-17 15:11:25 149.155.50.65 GET /news/ - 80 - 192.171.180.236 Mozilla/5.0+(Windows+NT+6.1;+Win64;+x64)+AppleWebKit/537.36+(KHTML,+like+Gecko)+Chrome/76.0.3809.132+Safari/537.36 http://dev.infohub.ukri.org/our-ukri/ dev.infohub.ukri.org 200 0 0 368"
+    result = described_class.from_string(line)
 
-    expect(e.date.day).to eql 17
-    expect(e.date.month).to eql 12
-    expect(e.date).to be_kind_of Time
-    expect(e.date.year).to eql 2019
-    expect(e.date.hour).to eql 15
-    expect(e.date.min).to eql 11
-    expect(e.date.sec).to eql 25
-    expect(e.date.zone).to eql "UTC"
+    expect(result.date.day).to eql 17
+    expect(result.date.month).to eql 12
+    expect(result.date).to be_kind_of Time
+    expect(result.date.year).to eql 2019
+    expect(result.date.hour).to eql 15
+    expect(result.date.min).to eql 11
+    expect(result.date.sec).to eql 25
+    expect(result.date.zone).to eql "UTC"
 
-    expect(e.server_ip).to be_kind_of IP::V4
-    expect(e.client_ip).to be_kind_of IP::V4
+    expect(result.server_ip).to be_kind_of IP::V4
+    expect(result.client_ip).to be_kind_of IP::V4
 
-    expect(e.port).to be_kind_of Integer
-    expect(e.status).to be_kind_of Integer
-    expect(e.substatus).to be_kind_of Integer
-    expect(e.win32_status).to be_kind_of Integer
+    expect(result.port).to be_kind_of Integer
+    expect(result.status).to be_kind_of Integer
+    expect(result.substatus).to be_kind_of Integer
+    expect(result.win32_status).to be_kind_of Integer
 
-    expect(e.time_taken).to be_kind_of Float
-    expect(e.time_taken).to eql 0.368
+    expect(result.time_taken).to be_kind_of Float
+    expect(result.time_taken).to eql 0.368
 
-    expect(e.username).to be_nil
+    expect(result.username).to be_nil
 
-    expect(e.user_agent).to eql "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36"
-    expect(e.user_referer).to eql "http://dev.infohub.ukri.org/our-ukri/"
+    expect(result.user_agent).to eql "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36"
+    expect(result.user_referer).to eql "http://dev.infohub.ukri.org/our-ukri/"
   end
 
   it "should handle correctly nil useragent" do
-    e = described_class.from_string("2011-06-20 00:01:02 38.111.242.43 GET /SharedControls/getListingThumbs.aspx img=48,13045,27801,25692,35,21568,21477,21477,10,18,46,8&premium=0|1|0|0|0|0|0|0|0|0|0|0&h=100&w=125&pos=175&scale=true 80 - 92.20.10.104 - 200 0 0 609 test oter now")
+    result = described_class.from_string("2011-06-20 00:01:02 38.111.242.43 GET /SharedControls/getListingThumbs.aspx img=48,13045,27801,25692,35,21568,21477,21477,10,18,46,8&premium=0|1|0|0|0|0|0|0|0|0|0|0&h=100&w=125&pos=175&scale=true 80 - 92.20.10.104 - 200 0 0 609 test oter now")
 
-    expect(e.user_agent).to be_nil
+    expect(result.user_agent).to be_nil
   end
 
   it "should handle strings containing invalid UTF-8 bytes" do
     # `/xE4` is an invalid UTF-8 byte in the query string
     invalid_line = "2019-12-17 15:11:25 149.155.50.65 GET /news?q=char\xE4 - 80 - 192.171.180.236 Mozilla http://dev.infohub.ukri.org/our-ukri/ dev.infohub.ukri.org 200 0 0 368"
-    e = described_class.from_string(invalid_line)
+    result = described_class.from_string(invalid_line)
     # It's replaced during parsing with `\uFFFD`, the standard replacement
     # character: https://www.fileformat.info/info/unicode/char/fffd/index.htm
-    expect(e.url).to eq "/news?q=char\uFFFD"
+    expect(result.url).to eq "/news?q=char\uFFFD"
   end
 end
 


### PR DESCRIPTION
IISAccessLogParser contained a long regular expression which was hard to
understand and maintain. This commit splits the regex into a more understandable
format.

I have also refactored the spec to be more readable. The first test
`it "can be constructed from string"` did not actually do anything!