### PR TITLE
Ingest Cloudfront log files with Sidekiq and parse their contents

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,9 @@ inherit_mode:
 Rails/Output:
   Exclude:
     - app/workers/ingest_w3c_log_worker.rb
+    - app/workers/ingest_cloudfront_log_worker.rb
 
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - spec/workers/ingest_w3c_log_worker_spec.rb
+    - spec/workers/ingest_cloudfront_log_worker_spec.rb

--- a/app/workers/ingest_cloudfront_log_worker.rb
+++ b/app/workers/ingest_cloudfront_log_worker.rb
@@ -1,0 +1,43 @@
+require "services"
+require "transition/import/hits"
+require "transition/import/cloudfront_access_log_parser"
+
+class IngestCloudfrontLogWorker
+  include Sidekiq::Worker
+  sidekiq_options retry: false, queue: "ingest"
+
+  def perform(bucket)
+    puts "Ingesting Cloudfront logs from: #{bucket}" unless Rails.env.test?
+
+    ::Services.s3.list_objects(bucket: bucket).each do |resp|
+      resp.contents.each do |object|
+        puts "Importing #{object.key}" unless Rails.env.test?
+
+        import_record = Transition::Import::Hits.find_import_record(object.key)
+        if import_record.content_hash == object.etag
+          puts "Already ingested #{object.key} - skipping" unless Rails.env.test?
+          next
+        else
+          import_record.content_hash = object.etag
+          import_record.save!
+        end
+
+        begin
+          tempfile = Tempfile.new("ingest")
+          ::Services.s3.get_object(
+            bucket: bucket, key: object.key, response_target: tempfile.path,
+          )
+          Transition::Import::Hits.from_cloudfront!(tempfile.path)
+        ensure
+          tempfile.unlink
+        end
+        Transition::Import::DailyHitTotals.from_hits!
+        Transition::Import::HitsMappingsRelations.refresh!
+
+        puts "Finished ingesting #{object.key}" unless Rails.env.test?
+      end
+    end
+
+    puts "Finished ingesting" unless Rails.env.test?
+  end
+end

--- a/app/workers/ingest_cloudfront_log_worker.rb
+++ b/app/workers/ingest_cloudfront_log_worker.rb
@@ -9,35 +9,40 @@ class IngestCloudfrontLogWorker
   def perform(bucket)
     puts "Ingesting Cloudfront logs from: #{bucket}" unless Rails.env.test?
 
-    ::Services.s3.list_objects(bucket: bucket).each do |resp|
-      resp.contents.each do |object|
-        puts "Importing #{object.key}" unless Rails.env.test?
+    # If multiple buckets are passed as e.g. "bucket1,bucket2, bucket3"
+    buckets = bucket.split(",").collect(&:strip)
 
-        import_record = Transition::Import::Hits.find_import_record(object.key)
-        if import_record.content_hash == object.etag
-          puts "Already ingested #{object.key} - skipping" unless Rails.env.test?
-          next
-        else
-          import_record.content_hash = object.etag
-          import_record.save!
+    buckets.each do |this_bucket|
+      ::Services.s3.list_objects(bucket: this_bucket).each do |resp|
+        resp.contents.each do |object|
+          puts "Importing #{object.key}" unless Rails.env.test?
+
+          import_record = Transition::Import::Hits.find_import_record(object.key)
+          if import_record.content_hash == object.etag
+            puts "Already ingested #{object.key} - skipping" unless Rails.env.test?
+            next
+          else
+            import_record.content_hash = object.etag
+            import_record.save!
+          end
+
+          begin
+            tempfile = Tempfile.new("ingest")
+            ::Services.s3.get_object(
+              bucket: this_bucket, key: object.key, response_target: tempfile.path,
+            )
+            Transition::Import::Hits.from_cloudfront!(tempfile.path)
+          ensure
+            tempfile.unlink
+          end
+          Transition::Import::DailyHitTotals.from_hits!
+          Transition::Import::HitsMappingsRelations.refresh!
+
+          puts "Finished ingesting #{object.key}" unless Rails.env.test?
         end
-
-        begin
-          tempfile = Tempfile.new("ingest")
-          ::Services.s3.get_object(
-            bucket: bucket, key: object.key, response_target: tempfile.path,
-          )
-          Transition::Import::Hits.from_cloudfront!(tempfile.path)
-        ensure
-          tempfile.unlink
-        end
-        Transition::Import::DailyHitTotals.from_hits!
-        Transition::Import::HitsMappingsRelations.refresh!
-
-        puts "Finished ingesting #{object.key}" unless Rails.env.test?
       end
-    end
 
-    puts "Finished ingesting" unless Rails.env.test?
+      puts "Finished ingesting" unless Rails.env.test?
+    end
   end
 end

--- a/app/workers/ingest_w3c_log_worker.rb
+++ b/app/workers/ingest_w3c_log_worker.rb
@@ -10,32 +10,37 @@ class IngestW3cLogWorker
   def perform(bucket)
     puts "Ingesting IIS W3C logs from: #{bucket}" unless Rails.env.test?
 
-    ::Services.s3.list_objects(bucket: bucket).each do |resp|
-      resp.contents.each do |object|
-        puts "Importing #{object.key}" unless Rails.env.test?
+    # If multiple buckets are passed as e.g. "bucket1,bucket2, bucket3"
+    buckets = bucket.split(",").collect(&:strip)
 
-        import_record = Transition::Import::Hits.find_import_record(object.key)
-        if import_record.content_hash == object.etag
-          puts "Already ingested #{object.key} - skipping" unless Rails.env.test?
-          next
-        else
-          import_record.content_hash = object.etag
-          import_record.save!
+    buckets.each do |this_bucket|
+      ::Services.s3.list_objects(bucket: this_bucket).each do |resp|
+        resp.contents.each do |object|
+          puts "Importing #{object.key}" unless Rails.env.test?
+
+          import_record = Transition::Import::Hits.find_import_record(object.key)
+          if import_record.content_hash == object.etag
+            puts "Already ingested #{object.key} - skipping" unless Rails.env.test?
+            next
+          else
+            import_record.content_hash = object.etag
+            import_record.save!
+          end
+
+          begin
+            tempfile = Tempfile.new("ingest")
+            ::Services.s3.get_object(
+              bucket: this_bucket, key: object.key, response_target: tempfile.path,
+            )
+            Transition::Import::Hits.from_iis_w3c!(tempfile.path)
+          ensure
+            tempfile.unlink
+          end
+          Transition::Import::DailyHitTotals.from_hits!
+          Transition::Import::HitsMappingsRelations.refresh!
+
+          puts "Finished ingesting #{object.key}" unless Rails.env.test?
         end
-
-        begin
-          tempfile = Tempfile.new("ingest")
-          ::Services.s3.get_object(
-            bucket: bucket, key: object.key, response_target: tempfile.path,
-          )
-          Transition::Import::Hits.from_iis_w3c!(tempfile.path)
-        ensure
-          tempfile.unlink
-        end
-        Transition::Import::DailyHitTotals.from_hits!
-        Transition::Import::HitsMappingsRelations.refresh!
-
-        puts "Finished ingesting #{object.key}" unless Rails.env.test?
       end
     end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -29,7 +29,12 @@ if ENV["REDIS_URL"].present?
       "daily_ingest_of_ukri_clf_logs" => {
         "class" => "IngestW3cLogWorker",
         "cron" => "0 19 * * *",
-        "args" => ENV["LOG_BUCKET_NAME"],
+        "args" => ENV["W3C_LOG_BUCKET_NAME"],
+      },
+      "daily_ingest_of_cloudfront_logs" => {
+        "class" => "IngestCloudfrontLogWorker",
+        "cron" => "0 20 * * *",
+        "args" => ENV["CLOUDFRONT_LOG_BUCKET_NAME"],
       },
     },
   )

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -23,6 +23,10 @@ end
 
 Sidekiq.logger.level = Logger::WARN if Rails.env.production?
 
+# If passing multiple buckets in the W3C_LOG_BUCKET_NAME & CLOUDFRONT_LOG_BUCKET_NAME
+# arguments, join them with `,` and they will be split into an array
+# e.g. W3C_LOG_BUCKET_NAME="bucket1,bucket2,bucket3"
+
 if ENV["REDIS_URL"].present?
   Sidekiq::Cron::Job.load_from_hash(
     {

--- a/lib/tasks/import/hits.rake
+++ b/lib/tasks/import/hits.rake
@@ -40,4 +40,10 @@ namespace :import do
     bucket = args[:bucket]
     IngestW3cLogWorker.new.perform(bucket)
   end
+
+  desc "Import hits from S3 files in Cloudfront log format"
+  task :from_cloudfront_files, [:bucket] => :environment do |_, args|
+    bucket = args[:bucket]
+    IngestCloudfrontLogWorker.new.perform(bucket)
+  end
 end

--- a/lib/transition/import/cloudfront_access_log_parser.rb
+++ b/lib/transition/import/cloudfront_access_log_parser.rb
@@ -75,6 +75,9 @@ module Transition
           mapping[:user_agent].tr!("+", " ") unless mapping[:user_agent].nil?
 
           mapping[:user_referer] = mapping[:"cs(Referer)"] unless ["-", nil].include?(mapping[:"cs(Referer)"])
+
+          mapping[:host] = mapping[:"x-host-header"]
+          mapping[:url] = mapping[:"cs-uri-stem"]
           new(mapping)
         end
       end

--- a/spec/lib/transition/import/cloudfront_access_log_parser_spec.rb
+++ b/spec/lib/transition/import/cloudfront_access_log_parser_spec.rb
@@ -55,6 +55,14 @@ describe Transition::Import::CloudfrontAccessLogParser::Entry do
     expect(line.user_referrer).to be_nil
   end
 
+  it "should contain the original host" do
+    expect(line.host).to eq("www.judiciary.uk")
+  end
+
+  it "should contain the url" do
+    expect(line.url).to eq("/wp-cron.php")
+  end
+
   it "should handle strings containing invalid UTF-8 bytes" do
     line_with_invalid_char = described_class.from_string("2020-05-29	23:54:02	DUB2-C1	618	54.195.247.25	GET	d12s8p8qcafwkr.cloudfront.net	/wp-cron.php	200	-	Wget/1.19.4%20(linux-gnu)	/news?q=char\xE4	-	Miss	b2_BwCohclTL3enMv28Y88rRVmftK2D5Y6W-FL75T_fp-6yzbeavmg==	www.judiciary.uk	https	154	0.147	-	TLSv1.2	ECDHE-RSA-AES128-GCM-SHA256	Miss	HTTP/1.1	-	-	48838	0.146	Miss	text/html;%20charset=UTF-8	0	-	-")
     expect(line_with_invalid_char.query).to eq "/news?q=char\uFFFD"

--- a/spec/lib/transition/import/hits_spec.rb
+++ b/spec/lib/transition/import/hits_spec.rb
@@ -266,6 +266,23 @@ describe Transition::Import::Hits do
     end
   end
 
+  describe ".from_cloudfront!" do
+    context "when there is a host that matches the IP address" do
+      it "imports the data" do
+        host = create :host, hostname: "www.judiciary.uk"
+
+        Transition::Import::Hits.from_cloudfront!("spec/fixtures/hits/cloudfront_example.log")
+
+        expect(Hit.count).to eql(2)
+        hit = Hit.first
+        expect(hit.path).to eql("/announcements/circuit-judge-appointment-beard/")
+        expect(hit.count).to eql(1)
+        expect(hit.hit_on).to eql(Date.new(2020, 5, 29))
+        expect(hit.host_id).to eql(host.id)
+      end
+    end
+  end
+
   describe ".from_s3!" do
     let(:bucket) { "bucket" }
     let(:s3) { Aws::S3::Client.new(stub_responses: true) }

--- a/spec/workers/ingest_cloudfront_log_worker_spec.rb
+++ b/spec/workers/ingest_cloudfront_log_worker_spec.rb
@@ -1,0 +1,45 @@
+require "./spec/spec_helper"
+
+describe IngestCloudfrontLogWorker, type: :worker do
+  let(:s3) { Aws::S3::Client.new(stub_responses: true) }
+
+  before do
+    allow(Services).to receive(:s3).and_return(s3)
+  end
+
+  describe "perform" do
+    let(:bucket) { "bucket-name" }
+    let(:key) { "path/hits.log" }
+    let(:fixture) { "cloudfront_example.log" }
+    let(:hash) { "abc123456def" }
+
+    before(:each) do
+      s3.stub_responses(:list_objects, contents: [{ key: key, etag: hash }])
+      s3.stub_responses(:get_object, body: File.open("spec/fixtures/hits/#{fixture}"))
+    end
+
+    it "fetches files from S3" do
+      Sidekiq::Testing.inline! do
+        expect(s3).to receive(:list_objects).with(bucket: bucket).and_call_original
+        expect(s3).to receive(:get_object).with(bucket: bucket, key: key, response_target: /ingest/).and_call_original
+        subject.perform(bucket)
+      end
+    end
+
+    it "asks the import service to ingest the file" do
+      expect(Transition::Import::Hits).to receive(:from_cloudfront!)
+      subject.perform(bucket)
+    end
+
+    it "uses the ingest queue" do
+      described_class.perform_async(bucket)
+      expect(Sidekiq::Queues["ingest"].size).to eq(1)
+    end
+
+    it "refreshes the analytics" do
+      expect(Transition::Import::DailyHitTotals).to receive(:from_hits!)
+      expect(Transition::Import::HitsMappingsRelations).to receive(:refresh!)
+      subject.perform(bucket)
+    end
+  end
+end

--- a/spec/workers/ingest_w3c_log_worker_spec.rb
+++ b/spec/workers/ingest_w3c_log_worker_spec.rb
@@ -9,6 +9,7 @@ describe IngestW3cLogWorker, type: :worker do
 
   describe "perform" do
     let(:bucket) { "bucket-name" }
+    let(:multiple_buckets) { "bucket-1,bucket-2" }
     let(:key) { "path/hits.log" }
     let(:fixture) { "iis_w3c_example.log" }
     let(:hash) { "abc123456def" }
@@ -23,6 +24,15 @@ describe IngestW3cLogWorker, type: :worker do
         expect(s3).to receive(:list_objects).with(bucket: bucket).and_call_original
         expect(s3).to receive(:get_object).with(bucket: bucket, key: key, response_target: /ingest/).and_call_original
         subject.perform(bucket)
+      end
+    end
+
+    it "handles multiple bucket names" do
+      Sidekiq::Testing.inline! do
+        expect(s3).to receive(:list_objects).with(bucket: "bucket-1").and_call_original
+        expect(s3).to receive(:list_objects).with(bucket: "bucket-2").and_call_original
+
+        subject.perform(multiple_buckets)
       end
     end
 


### PR DESCRIPTION
Ingest Cloudfront log files from s3 in the same way as W3C IIS log files are ingested. Use a Sidekiq worker to ingest them once a day, and the new Cloudfront log parser to parse their contents. 