### PR TITLE
Address CVE-2019-16782

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 gem "rails", "6.0.3.5"
 
 gem "activerecord-import"
-gem "activerecord-session_store"
+gem "activerecord-session_store", github: "rails-lts/activerecord-session_store", branch: "secure-session-store"
 gem "acts-as-taggable-on"
 gem "apache_log-parser"
 gem "aws-sdk-s3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/rails-lts/activerecord-session_store.git
+  revision: d091c7ea819350bbb9433d4dd065379832d593a3
+  branch: secure-session-store
+  specs:
+    activerecord-session_store (1.1.3)
+      actionpack (>= 5.2.4.1)
+      activerecord (>= 5.2.4.1)
+      multi_json (~> 1.11, >= 1.11.2)
+      rack (>= 2.0.8, < 3)
+      railties (>= 5.2.4.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -47,12 +59,6 @@ GEM
       activesupport (= 6.0.3.5)
     activerecord-import (1.0.8)
       activerecord (>= 3.2)
-    activerecord-session_store (1.1.3)
-      actionpack (>= 4.0)
-      activerecord (>= 4.0)
-      multi_json (~> 1.11, >= 1.11.2)
-      rack (>= 1.5.2, < 3)
-      railties (>= 4.0)
     activestorage (6.0.3.5)
       actionpack (= 6.0.3.5)
       activejob (= 6.0.3.5)
@@ -579,7 +585,7 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord-import
-  activerecord-session_store
+  activerecord-session_store!
   acts-as-taggable-on
   apache_log-parser
   aws-sdk-s3


### PR DESCRIPTION
This addresses CVE-2019-16782

There has been a [vulnerability in the wild][1] around session hijacks in Rack and related frameworks for a while now, but this has been fixed in Rack and Rails for a while now. There's a [fix for the upstream version of ActiverecordSessionStore since late 2019][2], but this hasn't been merged yet.

We weren't aware of this issue until recently, as it's only [just been added to the Ruby Advisory DB][3]

This uses a fork of the upstream gem, [as suggested in the original PR][4] to fix  the immediate issue.

[1]:https://nvd.nist.gov/vuln/detail/CVE-2019-16782
[2]:https://github.com/rails/activerecord-session_store/pull/151
[3]:https://github.com/rubysec/ruby-advisory-db/pull/462
[4]:https://github.com/rails/activerecord-session_store/pull/151#issuecomment-631705247